### PR TITLE
ci: improve GitHub Actions workflows for octo-lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.20'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build
+        run: CGO_ENABLED=0 go build -v ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Test
+        run: go test -race -count=1 -timeout 5m ./...
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Vet
+        run: go vet ./...

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -8,6 +8,4 @@ jobs:
   welcome:
     permissions:
       issues: write
-    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@3d90d99236e0427a4fbe5b8f25b209ac0b799b3e

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -1,0 +1,13 @@
+name: Issue Welcome
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    permissions:
+      issues: write
+    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -1,12 +1,14 @@
 name: Octo PR Feed
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened, ready_for_review, review_requested]
+
+permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@c6c51348fccac99161166dce1b52dec1063aeea2
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-merged-done.yml
+++ b/.github/workflows/pr-merged-done.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}  # GITHUB_TOKEN not used; PROJECT_TOKEN is passed explicitly
+
 jobs:
   move-to-done:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch

--- a/.github/workflows/pr-merged-done.yml
+++ b/.github/workflows/pr-merged-done.yml
@@ -9,6 +9,6 @@ permissions: {}  # GITHUB_TOKEN not used; PROJECT_TOKEN is passed explicitly
 jobs:
   move-to-done:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch
-    uses: Mininglamp-OSS/.github/.github/workflows/pr-merged-done.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/pr-merged-done.yml@3d90d99236e0427a4fbe5b8f25b209ac0b799b3e
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Changes

### A5: Add CI workflow for Go 1.20 library

Added `.github/workflows/ci.yml` with build, test, and vet jobs (no lint for base library):
- Triggers on push/PR to `main`
- Go version: 1.20
- `build`: `CGO_ENABLED=0 go build -v ./...`
- `test` (after build): `go test -race -count=1 -timeout 5m ./...`
- `vet`: `go vet ./...`

### B: Migrate `octo-pr-feed.yml` to `pull_request_target` + pinned SHA + `permissions: {}`

- Changed trigger from `pull_request` to `pull_request_target` so org secrets are available for fork PRs
- Pinned reusable workflow to SHA `c6c51348fccac99161166dce1b52dec1063aeea2` for supply-chain security
- Added `permissions: {}` to restrict default token permissions

### D: Add `permissions: {}` to `pr-merged-done.yml`

Adds explicit `permissions: {}` block between `on:` and `jobs:` to clarify that `GITHUB_TOKEN` is not used; only `PROJECT_TOKEN` is passed explicitly.

### E: Add `issue-welcome.yml`

Added missing `.github/workflows/issue-welcome.yml` that posts a welcome comment when new issues are opened, using the org-level reusable workflow.