### PR TITLE
feat(config): add NewPersonalMsgSendReq builder for authoritative payload.space_id

### DIFF
--- a/config/msg_personal.go
+++ b/config/msg_personal.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+)
+
+// PersonalMsgOptions carries the optional MsgSendReq fields beyond the
+// mandatory authoritative-payload contract enforced by NewPersonalMsgSendReq.
+//
+// Only fields a PERSONAL DM dispatcher legitimately controls are exposed.
+// channel_type is set to ChannelTypePerson by the builder unconditionally;
+// payload is encoded by the builder after authoritative space_id semantics
+// have been applied.
+type PersonalMsgOptions struct {
+	Header      MsgHeader
+	Setting     uint8
+	StreamNo    string
+	Subscribers []string
+}
+
+// NewPersonalMsgSendReq returns a *MsgSendReq for a PERSONAL (channel_type=1)
+// dispatch with authoritative payload.space_id semantics applied to payload
+// before encoding.
+//
+// Contract:
+//   - senderSpaceID != ""  → payload["space_id"] = senderSpaceID (server overrides
+//     any client-supplied value; this is the only authoritative source the
+//     receiver-side SpaceFilter can trust on PERSONAL channels because WuKongIM
+//     has no Space concept on channel_type=1).
+//   - senderSpaceID == ""  → payload["space_id"] is stripped (fail-closed).
+//     The empty case means the dispatcher has no Space context (orphan bot,
+//     non-Space deployment, missing X-Space-ID middleware); we MUST NOT trust
+//     a client-supplied value in that branch — see Mininglamp-OSS/octo-server
+//     PR#35 R3 review (YUJ-660 High-3) for the fail-open hole this closes.
+//
+// Channel type is always set to ChannelTypePerson; callers MUST verify the
+// channel is in fact PERSONAL before invoking this builder. Use the regular
+// MsgSendReq literal for GROUP / COMMUNITY_TOPIC / RTC / etc.
+//
+// payload may be nil; an empty map is materialised. The map is mutated in
+// place (consistent with octo-server's enrichPayloadWithSpaceID helpers) and
+// then JSON-encoded into MsgSendReq.Payload.
+//
+// This builder is the defense-in-depth layer for Mininglamp-OSS/octo-server#37
+// (PR#35 follow-up Medium-1). New PERSONAL DM call sites added in either
+// repository SHOULD use this builder so payload.space_id correctness becomes
+// a property of construction rather than caller diligence.
+func NewPersonalMsgSendReq(
+	channelID string,
+	fromUID string,
+	payload map[string]interface{},
+	senderSpaceID string,
+	opts PersonalMsgOptions,
+) *MsgSendReq {
+	if payload == nil {
+		payload = make(map[string]interface{})
+	}
+	if senderSpaceID != "" {
+		payload["space_id"] = senderSpaceID
+	} else {
+		// Fail-closed: server has no authoritative Space context, so any
+		// client-supplied space_id is untrusted. Strip it. Receivers will
+		// fall through to their own (cache-warmed) SpaceFilter logic.
+		delete(payload, "space_id")
+	}
+	return &MsgSendReq{
+		Header:      opts.Header,
+		Setting:     opts.Setting,
+		FromUID:     fromUID,
+		ChannelID:   channelID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		StreamNo:    opts.StreamNo,
+		Subscribers: opts.Subscribers,
+		Payload:     []byte(util.ToJson(payload)),
+	}
+}

--- a/config/msg_personal_test.go
+++ b/config/msg_personal_test.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+)
+
+func decodePayload(t *testing.T, b []byte) map[string]interface{} {
+	t.Helper()
+	out := map[string]interface{}{}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("payload not JSON: %v (raw=%s)", err, string(b))
+	}
+	return out
+}
+
+// senderSpaceID non-empty → server overrides any client-supplied value.
+func TestNewPersonalMsgSendReq_OverridesClientWhenSenderSpaceIDProvided(t *testing.T) {
+	req := NewPersonalMsgSendReq(
+		"peer_uid",
+		"sender_uid",
+		map[string]interface{}{
+			"content":  "hi",
+			"type":     1,
+			"space_id": "client_forged_space",
+		},
+		"server_authoritative_space",
+		PersonalMsgOptions{Header: MsgHeader{RedDot: 1}},
+	)
+	if req == nil {
+		t.Fatal("nil req")
+	}
+	if req.ChannelType != common.ChannelTypePerson.Uint8() {
+		t.Errorf("ChannelType=%d, want PERSONAL=%d", req.ChannelType, common.ChannelTypePerson.Uint8())
+	}
+	if req.ChannelID != "peer_uid" || req.FromUID != "sender_uid" {
+		t.Errorf("identity fields not preserved: %+v", req)
+	}
+	got := decodePayload(t, req.Payload)
+	if got["space_id"] != "server_authoritative_space" {
+		t.Errorf("space_id=%v, want server_authoritative_space (client value MUST be overridden)", got["space_id"])
+	}
+	if got["content"] != "hi" {
+		t.Errorf("content not preserved, got %v", got["content"])
+	}
+}
+
+// senderSpaceID non-empty → injects when payload has no space_id at all.
+func TestNewPersonalMsgSendReq_InjectsWhenAbsent(t *testing.T) {
+	req := NewPersonalMsgSendReq(
+		"peer_uid",
+		"sender_uid",
+		map[string]interface{}{"content": "hi"},
+		"server_authoritative_space",
+		PersonalMsgOptions{},
+	)
+	got := decodePayload(t, req.Payload)
+	if got["space_id"] != "server_authoritative_space" {
+		t.Errorf("space_id=%v, want server_authoritative_space", got["space_id"])
+	}
+}
+
+// senderSpaceID empty + client space_id present → STRIP (fail-closed).
+// This is the YUJ-660 High-3 fix encoded into the builder.
+func TestNewPersonalMsgSendReq_StripsClientSpaceIDWhenSenderEmpty(t *testing.T) {
+	req := NewPersonalMsgSendReq(
+		"peer_uid",
+		"sender_uid",
+		map[string]interface{}{
+			"content":  "hi",
+			"space_id": "client_forged_space",
+		},
+		"",
+		PersonalMsgOptions{},
+	)
+	got := decodePayload(t, req.Payload)
+	if _, present := got["space_id"]; present {
+		t.Errorf("space_id MUST be stripped when senderSpaceID empty, got %v", got["space_id"])
+	}
+	if got["content"] != "hi" {
+		t.Errorf("content not preserved, got %v", got["content"])
+	}
+}
+
+// senderSpaceID empty + no client space_id → still no space_id in output.
+func TestNewPersonalMsgSendReq_LeavesAbsentWhenBothEmpty(t *testing.T) {
+	req := NewPersonalMsgSendReq(
+		"peer_uid",
+		"sender_uid",
+		map[string]interface{}{"content": "hi"},
+		"",
+		PersonalMsgOptions{},
+	)
+	got := decodePayload(t, req.Payload)
+	if _, present := got["space_id"]; present {
+		t.Errorf("space_id appeared from nowhere, got %v", got["space_id"])
+	}
+}
+
+// nil payload is materialised to an empty map; all other invariants hold.
+func TestNewPersonalMsgSendReq_NilPayloadInitialised(t *testing.T) {
+	req := NewPersonalMsgSendReq("peer_uid", "sender_uid", nil, "spaceA", PersonalMsgOptions{})
+	got := decodePayload(t, req.Payload)
+	if got["space_id"] != "spaceA" {
+		t.Errorf("space_id=%v, want spaceA", got["space_id"])
+	}
+}
+
+// Optional fields propagate end-to-end.
+func TestNewPersonalMsgSendReq_OptionalFieldsPropagate(t *testing.T) {
+	req := NewPersonalMsgSendReq(
+		"peer_uid",
+		"sender_uid",
+		map[string]interface{}{"content": "hi"},
+		"spaceA",
+		PersonalMsgOptions{
+			Header:      MsgHeader{NoPersist: 1, RedDot: 1, SyncOnce: 1},
+			Setting:     0x10,
+			StreamNo:    "stream-1",
+			Subscribers: []string{"a", "b"},
+		},
+	)
+	if req.Header.RedDot != 1 || req.Header.NoPersist != 1 || req.Header.SyncOnce != 1 {
+		t.Errorf("Header lost: %+v", req.Header)
+	}
+	if req.Setting != 0x10 {
+		t.Errorf("Setting lost: %d", req.Setting)
+	}
+	if req.StreamNo != "stream-1" {
+		t.Errorf("StreamNo lost: %s", req.StreamNo)
+	}
+	if len(req.Subscribers) != 2 || req.Subscribers[0] != "a" || req.Subscribers[1] != "b" {
+		t.Errorf("Subscribers lost: %v", req.Subscribers)
+	}
+}
+
+// ChannelType is always PERSONAL regardless of caller intent — defensive.
+func TestNewPersonalMsgSendReq_AlwaysPersonalChannelType(t *testing.T) {
+	req := NewPersonalMsgSendReq("peer_uid", "sender_uid", nil, "", PersonalMsgOptions{})
+	if req.ChannelType != common.ChannelTypePerson.Uint8() {
+		t.Errorf("ChannelType=%d, want PERSONAL=%d", req.ChannelType, common.ChannelTypePerson.Uint8())
+	}
+}


### PR DESCRIPTION
## Summary

Adds `config.NewPersonalMsgSendReq(...)` — a defense-in-depth builder for
PERSONAL (channel_type=1) `MsgSendReq` construction.

The builder encodes the authoritative `payload.space_id` contract from
[Mininglamp-OSS/octo-server PR#35 (Fixes #33)][1] into a single octo-lib API so
PERSONAL DM dispatchers no longer need to remember to call enrichment helpers
manually.

## Contract

| `senderSpaceID` | `payload["space_id"]` outcome |
|---|---|
| non-empty | overwritten with `senderSpaceID` (server is authoritative) |
| empty | **stripped** (fail-closed) |

The fail-closed empty branch closes the YUJ-660 High-3 fail-open hole:
dispatchers without Space context (orphan bot, missing X-Space-ID middleware,
non-Space deployment) MUST NOT trust a client-supplied value, since WuKongIM
has no Space concept on PERSONAL channels and the receiver-side SpaceFilter
has no other authoritative signal to fall back on.

`ChannelType` is always set to `ChannelTypePerson`; callers MUST verify the
channel is in fact PERSONAL before invoking. The optional `PersonalMsgOptions`
struct exposes `Header` / `Setting` / `StreamNo` / `Subscribers` without
re-exposing `payload` or `channel_type`.

## Tests

`config/msg_personal_test.go` covers:
- override (client value replaced)
- inject (no client value)
- strip (empty senderSpaceID + client value present → fail-closed)
- leave-absent (both empty)
- nil-payload materialisation
- optional-field propagation
- `channel_type=Person` invariant

```
$ go test ./config/...
ok  	github.com/Mininglamp-OSS/octo-lib/config	2.5s
```

`go build ./...` and `go vet ./...` clean.

## Why a builder, not a free function

A naked free function on `[]byte` payload was considered (matches issue body
proposal) but rejected: the authoritative override needs to mutate the JSON
map, and round-tripping through `[]byte → map → []byte` is what the helper is
hiding from callers. The map-in / `*MsgSendReq`-out signature lets the
encoding live in one place.

## Out-of-scope (handled by the matching octo-server PR)

- Migration of the ~10 PERSONAL `MsgSendReq{}` call sites listed in the issue.
- CI lint that rejects new direct `MsgSendReq{... ChannelType: ChannelTypePerson ...}`
  literals outside the builder.
- Per-call-site `senderSpaceID` resolution (re-uses the existing
  `enrichBotPayloadWithSpaceID` / `spacepkg.GetSpaceID` / robot resolver
  helpers added in PR#35).

## Refs

- Refs Mininglamp-OSS/octo-server#37
- Background: Mininglamp-OSS/octo-server#35 (closes #33), R3/R4 review
  iterations recorded in YUJ-644 / YUJ-660.

[1]: https://github.com/Mininglamp-OSS/octo-server/pull/35
