### PR TITLE
chore(workflows): pin reusable workflow refs to @v1

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -11,6 +11,6 @@ permissions: {}
 
 jobs:
   add-to-project:
-    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@239d0b47cfe1947d5e6de826e795feac4ed90562
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@v1
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -8,4 +8,4 @@ jobs:
   welcome:
     permissions:
       issues: write
-    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@3d90d99236e0427a4fbe5b8f25b209ac0b799b3e
+    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@v1

--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       issue_number: ${{ github.event.issue.number }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@c6c51348fccac99161166dce1b52dec1063aeea2
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Pin all reusable workflow references to `@v1` for stable, version-locked behavior.

**Before:** Mixed `@main` and hardcoded commit SHAs
**After:** All callers use `Mininglamp-OSS/.github/...@v1`

## Why

The `.github` repo has been tagged `v1` as the stable baseline. Using a version tag
ensures callers get a predictable, reviewed version of the shared workflows.

No caller-side logic changes — this is a reference update only.