### PR TITLE
fix(ci): upgrade Go 1.24, add lint, add CI status notifications, pin action SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25.x'
 
 jobs:
   build:
@@ -59,7 +59,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v1.64.5
+          version: v2.12.2
           args: --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.20'
+  GO_VERSION: '1.24'
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Build
@@ -31,10 +31,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Test
@@ -44,9 +43,23 @@ jobs:
     name: Vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Vet
         run: go vet ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        with:
+          version: v1.64.5
+          args: --timeout=5m

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -6,6 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
+permissions: {}
+
 jobs:
   notify:
     uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@v1

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -6,7 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
-permissions: {}
+permissions:
+  actions: read
 
 jobs:
   notify:

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -1,0 +1,21 @@
+name: Octo CI Status
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@v1
+    with:
+      repo_name: ${{ github.event.workflow_run.repository.name }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+      conclusion: ${{ github.event.workflow_run.conclusion }}
+      run_id: ${{ github.event.workflow_run.id }}
+      run_url: ${{ github.event.workflow_run.html_url }}
+      project_group_id: "6095b6ded00046009e72882ce4067289"
+      workflow_id: ${{ github.event.workflow_run.workflow_id }}
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+run:
+  timeout: 5m
+linters:
+  disable-all: true
+  enable:
+    - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,6 @@ version: "2"
 run:
   timeout: 5m
 linters:
-  disable-all: true
+  default: none
   enable:
     - govet


### PR DESCRIPTION
## Changes

### 🟠 H-5: Add octo-ci-status.yml
Notify Octo IM `📦 octo-lib` channel when CI status changes on main branch.

### 🟡 M-2: Upgrade Go to 1.24
Go 1.20 is EOL. Upgrade to current stable 1.24.

### 🟡 M-5: Add golangci-lint job
octo-lib is the shared foundation for all Go services in the org — it deserves the highest code-quality bar. Add `golangci-lint v1.64.5` to match octo-server and octo-smart-summary.

### 🟡 M-4 alignment: Remove `needs: build` from test job
`go test` rebuilds anyway; run test/vet/lint in parallel.

### 🟢 L-1: Pin action SHAs
Pin `actions/checkout` and `actions/setup-go` to verified commit SHAs for supply-chain security.