### PR TITLE
fix(pr-feed): use pull_request trigger, pin SHA, add feed_group_id

### DIFF
--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -1,14 +1,15 @@
 name: Octo PR Feed
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, closed, reopened, ready_for_review, review_requested]
 
 permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@v1
+    if: ${{ !github.event.pull_request.draft }}
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@db17008c4190b88ebd6589948efe62a02ec4d085
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}
@@ -20,6 +21,7 @@ jobs:
       pr_deletions: ${{ github.event.pull_request.deletions }}
       pr_changed_files: ${{ github.event.pull_request.changed_files }}
       event_action: ${{ github.event.action }}
-      project_group_id: 6095b6ded00046009e72882ce4067289
+      feed_group_id: "1c303c142e9840f2a9b46c10b0972e8d"
+      project_group_id: "6095b6ded00046009e72882ce4067289"
     secrets:
       OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Phase 2 of the pr-feed security & maintainability improvement series.

## Changes

### `.github/workflows/octo-pr-feed.yml`

- **`pull_request_target` → `pull_request`** (P0 security fix): eliminates the risk of secrets exposure via malicious fork PRs
- **Pin reusable workflow to commit SHA** `db17008c` instead of mutable `@v1` tag
- **Add `feed_group_id` input** (required by Phase 1 breaking change in `.github` PR #18)
- **Skip draft PRs** with `if: ${{ !github.event.pull_request.draft }}`

## Related

- Phase 1 (`.github` PR #18): https://github.com/Mininglamp-OSS/.github/pull/18
