### PR TITLE
feat(ci): refine CI + add stale and PR labeler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           filters: |
             code:
               - '**/*.go'
+              - '**/*.proto'
               - 'go.mod'
               - 'go.sum'
               - 'Makefile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,11 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      # For push events the paths-filter step is skipped; default to 'true'
-      # so downstream jobs always run on direct main pushes.
-      code: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.code }}
+      # For push events the paths-filter step is skipped; default to 'false'
+      # (code=false is not used for push — push always runs). We use a forward
+      # positive pattern list so the logic is unambiguous: code=true when at
+      # least one changed file matches a known source pattern.
+      code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: github.event_name == 'pull_request'
@@ -49,17 +51,18 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
-          # Negation patterns (! prefix) correctly exclude matched files even
-          # when '**' would otherwise match them — a .md file matches '**' but
-          # is then eliminated by '!**/*.md', leaving code: false for docs-only
-          # PRs. This is standard minimatch behaviour; predicate-quantifier
-          # defaults to 'any' which is exactly what we want.
+          # Positive patterns only — no negation, no predicate-quantifier needed.
+          # code=true when at least one changed file matches a source pattern.
+          # Docs-only PRs (only *.md / docs/) won't match any pattern → code=false
+          # and downstream jobs are skipped (skipped counts as passing for required
+          # status checks).
           filters: |
             code:
-              - '**'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!.github/ISSUE_TEMPLATE/**'
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.github/workflows/**'
 
   build:
     needs: [changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,18 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
 
 permissions:
   contents: read
@@ -18,6 +27,7 @@ env:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +39,7 @@ jobs:
         run: CGO_ENABLED=0 go build -v ./...
 
   test:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Test
     runs-on: ubuntu-latest
     needs: build
@@ -41,6 +52,7 @@ jobs:
         run: go test -race -count=1 -timeout 5m ./...
 
   vet:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Vet
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,15 @@ name: CI
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    # converted_to_draft is kept intentionally: it creates "skipped" check entries
+    # that satisfy required-check branch-protection rules when a PR is demoted
+    # back to draft, preventing stale "pending" statuses from the last real push.
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - ".github/ISSUE_TEMPLATE/**"
+    # paths-ignore is intentionally NOT set here — workflow-level path filtering
+    # prevents GitHub from creating any check run, which deadlocks required-status
+    # checks on docs-only PRs. Path-based skipping is handled by the `changes`
+    # preflight job below (dorny/paths-filter produces 'skipped' statuses that
+    # GitHub counts as passing for required checks).
   push:
     branches: [main]
     paths-ignore:
@@ -26,8 +30,42 @@ env:
   GO_VERSION: '1.20'
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      # For push events the paths-filter step is skipped; default to 'true'
+      # so downstream jobs always run on direct main pushes.
+      code: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          # Negation patterns (! prefix) correctly exclude matched files even
+          # when '**' would otherwise match them — a .md file matches '**' but
+          # is then eliminated by '!**/*.md', leaving code: false for docs-only
+          # PRs. This is standard minimatch behaviour; predicate-quantifier
+          # defaults to 'any' which is exactly what we want.
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+
   build:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -39,10 +77,12 @@ jobs:
         run: CGO_ENABLED=0 go build -v ./...
 
   test:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
     name: Test
     runs-on: ubuntu-latest
-    needs: build
+    needs: [changes]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -52,7 +92,10 @@ jobs:
         run: go test -race -count=1 -timeout 5m ./...
 
   vet:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
     name: Vet
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  label:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-labeler.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      repo_owner: ${{ github.repository_owner }}
+      repo_name: ${{ github.event.repository.name }}
+    permissions:
+      issues: write
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,15 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  # pull_request_target runs in the context of the base repo and retains write
+  # access even for fork PRs — required because the reusable labeler calls the
+  # GitHub REST API to set labels and post comments (both need write tokens).
+  #
+  # Security: this workflow does NOT check out or execute any code from the PR
+  # branch; it only passes the PR number / owner / repo name to a reusable
+  # workflow that performs only API calls against the base repo. This matches
+  # the pattern used by auto-add-to-project.yml and octo-pr-feed.yml.
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
     types: [opened, synchronize, reopened]
 
 permissions: {}
@@ -16,4 +24,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    secrets: inherit
+    # secrets: intentionally omitted — reusable-pr-labeler.yml uses only the
+    # inherited GITHUB_TOKEN granted via the job-level permissions above.
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,4 +26,3 @@ jobs:
       pull-requests: write
     # secrets: intentionally omitted — reusable-pr-labeler.yml uses only the
     # inherited GITHUB_TOKEN granted via the job-level permissions above.
-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
## Changes

- **ci.yml**: draft PRs are now skipped; docs/markdown-only changes no longer trigger full CI
- **stale.yml**: four-lane stale management (unassigned/assigned × issues/PRs) via shared reusable workflow
- **labeler.yml**: auto size labels (XS/S/M/L/XL) + dependency-changed detection + maintainer checklist comment

## Dependencies

Requires `Mininglamp-OSS/.github#feat/automation-p0-shared-workflows` (PR #25) to be merged first — the reusable workflows `reusable-stale.yml` and `reusable-pr-labeler.yml` must be on `main` for stale and labeler to be functional.

## Part of P0 automation rollout

Modeled after openclaw best practices.