### PR TITLE
feat(ci): add CodeQL security scan and Workflow Sanity check

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@main
+    with:
+      language: go
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -1,0 +1,19 @@
+name: Workflow Sanity
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+jobs:
+  sanity:
+    uses: Mininglamp-OSS/.github/.github/workflows/workflow-sanity.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Changes

### `codeql.yml` (new)
Go CodeQL security analysis via shared reusable workflow.
- queries: `security-extended`
- Triggers: push to main / PR opened-synced-reopened / daily cron 06:00 UTC / manual
- Skip draft PRs and docs-only changes
- Concurrency group prevents parallel duplicate runs

### `workflow-sanity.yml` (new)
Validates workflow quality on CI file changes:
- No-tabs scan (Python3 across \*.yml + \*.yaml)
- actionlint v1.7.12 static analysis (SHA-256 verified download)

## Merge order
**Merge `Mininglamp-OSS/.github` PR #26 first** — `reusable-codeql.yml` and `workflow-sanity.yml` must be on `main` before these callers work.

## Part of P1 automation rollout