### PR TITLE
feat(ci): simplify octo-issue-feed to new/reopen only

### DIFF
--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -2,19 +2,19 @@ name: Octo Issue Feed
 
 on:
   issues:
-    types: [opened, closed, reopened, labeled]
+    types: [opened, reopened]
+
+permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@v1
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
     with:
       repo_name: ${{ github.event.repository.name }}
       issue_number: ${{ github.event.issue.number }}
       issue_title: ${{ github.event.issue.title }}
       issue_url: ${{ github.event.issue.html_url }}
       issue_author: ${{ github.event.issue.user.login }}
-      issue_labels: ${{ toJson(github.event.issue.labels.*.name) }}
       event_action: ${{ github.event.action }}
-      project_group_id: 6095b6ded00046009e72882ce4067289
     secrets:
       OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Simplifies the `octo-issue-feed.yml` caller following the product decision to:
1. Only forward **new issue (opened)** and **reopened** events — close/label/etc. are ignored
2. Send to the shared **issue-feed group only** (per-repo project group removed)
3. Remove IssueTriage bot mention (deprecated)

### Changes
- Trigger: `[opened, closed, reopened, labeled]` → `[opened, reopened]`
- Removed: `issue_labels`, `project_group_id` from `with:` block
- Switched: `@v1` → `@main` to pick up new reusable after `.github` PR #28 merges
- Added: `permissions: {}` at workflow level

## Merge order
**Merge `.github` PR #28 first** — the reusable `octo-issue-feed.yml` on main must match this caller interface before these callers work correctly.