### PR TITLE
fix(ci): grant both issues: write and pull-requests: write

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -17,3 +17,4 @@ jobs:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
     permissions:
       issues: write
+      pull-requests: write


### PR DESCRIPTION
Follow-up permission fix. Both `issues: write` and `pull-requests: write` are needed — matches `labeler.yml` established pattern.