### PR TITLE
feat(config): add S3Config for AWS S3 and S3-compatible storage backends

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -142,6 +142,7 @@ type Config struct {
 	Seaweed     SeaweedConfig // seaweedfs配置
 	Qiniu       QiniuConfig   // 七牛云配置
 	COS         COSConfig     // 腾讯云COS配置
+	S3          S3Config      // S3 / S3兼容存储配置（AWS S3、Cloudflare R2、Backblaze B2、Wasabi 等）
 
 	// ---------- 短信运营商 ----------
 	SMSCode                string // 模拟的短信验证码
@@ -648,6 +649,15 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	// 环境变量覆盖（安全：避免密钥硬编码在配置文件中）
 	StringEnv(&c.COS.SecretID, "TS_COS_SECRET_ID")
 	StringEnv(&c.COS.SecretKey, "TS_COS_SECRET_KEY")
+	// S3 / S3兼容存储
+	c.S3.Endpoint = c.getString("s3.endpoint", c.S3.Endpoint)
+	c.S3.Region = c.getString("s3.region", c.S3.Region)
+	c.S3.Bucket = c.getString("s3.bucket", c.S3.Bucket)
+	c.S3.AccessKeyID = c.getString("s3.accessKeyID", c.S3.AccessKeyID)
+	c.S3.SecretAccessKey = c.getString("s3.secretAccessKey", c.S3.SecretAccessKey)
+	c.S3.BucketURL = c.getString("s3.bucketURL", c.S3.BucketURL)
+	c.S3.Prefix = c.getString("s3.prefix", c.S3.Prefix)
+	c.S3.UsePathStyle = c.getBool("s3.usePathStyle", c.S3.UsePathStyle)
 
 	//#################### 短信服务 ####################
 	c.SMSCode = c.getString("smsCode", c.SMSCode)
@@ -1052,6 +1062,54 @@ type QiniuConfig struct {
 	BucketName string
 	AccessKey  string
 	SecretKey  string
+}
+
+// S3Config configures any S3-compatible object storage backend.
+// Use this for AWS S3 or third-party providers that speak the S3 protocol
+// (Cloudflare R2, Backblaze B2, Wasabi, etc.). Tencent Cloud COS and MinIO
+// continue to be configured via their existing dedicated blocks for
+// backward compatibility.
+type S3Config struct {
+	// Endpoint is the S3 API hostname, without scheme.
+	// Examples:
+	//   AWS S3:        s3.us-west-2.amazonaws.com
+	//   Cloudflare R2: <accountid>.r2.cloudflarestorage.com
+	//   MinIO:         minio.example.com:9000
+	// REQUIRED — no default.
+	Endpoint string
+
+	// Region is the SigV4 signing region.
+	// Examples: us-west-2, ap-southeast-1, auto (R2).
+	// REQUIRED — must match the bucket's actual region for AWS; some
+	// providers accept any value (e.g. R2 uses "auto").
+	Region string
+
+	// Bucket is the single bucket all uploads target. Object keys carry
+	// their own logical prefix (chat/, moment/, ...), so a single bucket
+	// is the recommended deployment topology.
+	Bucket string
+
+	// AccessKeyID / SecretAccessKey are the long-lived IAM credentials
+	// for the bucket. See the security docs for the minimum IAM policy.
+	AccessKeyID     string
+	SecretAccessKey string
+
+	// BucketURL, when set, overrides the URL returned by DownloadURL and
+	// signed against by presigned GET/PUT. Use this for CDN-fronted
+	// buckets or custom domains. Must be scheme://host[:port] with no
+	// path component (same contract as MinioConfig.DownloadURL).
+	BucketURL string
+
+	// Prefix is an optional object-key prefix for multi-environment
+	// isolation (e.g. "staging/" or "prod/"). Mirrors COSConfig.Prefix.
+	Prefix string
+
+	// UsePathStyle forces path-style addressing
+	// (https://endpoint/bucket/key) instead of virtual-hosted style
+	// (https://bucket.endpoint/key). Required by some S3 gateways and
+	// by AWS for very old buckets or path-style-only endpoints; rarely
+	// needed for AWS S3 in 2026, default false.
+	UsePathStyle bool
 }
 
 // COSConfig 腾讯云COS配置

--- a/config/config.go
+++ b/config/config.go
@@ -658,6 +658,12 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	c.S3.BucketURL = c.getString("s3.bucketURL", c.S3.BucketURL)
 	c.S3.Prefix = c.getString("s3.prefix", c.S3.Prefix)
 	c.S3.UsePathStyle = c.getBool("s3.usePathStyle", c.S3.UsePathStyle)
+	// 环境变量覆盖（安全：避免长期凭据硬编码在配置文件中）
+	// 先读取项目专属变量，再让 AWS 标准变量覆盖，便于 IAM role / IRSA 等 AWS 原生工作流
+	StringEnv(&c.S3.AccessKeyID, "TS_S3_ACCESS_KEY_ID")
+	StringEnv(&c.S3.SecretAccessKey, "TS_S3_SECRET_ACCESS_KEY")
+	StringEnv(&c.S3.AccessKeyID, "AWS_ACCESS_KEY_ID")
+	StringEnv(&c.S3.SecretAccessKey, "AWS_SECRET_ACCESS_KEY")
 
 	//#################### 短信服务 ####################
 	c.SMSCode = c.getString("smsCode", c.SMSCode)

--- a/config/config.go
+++ b/config/config.go
@@ -659,11 +659,13 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	c.S3.Prefix = c.getString("s3.prefix", c.S3.Prefix)
 	c.S3.UsePathStyle = c.getBool("s3.usePathStyle", c.S3.UsePathStyle)
 	// 环境变量覆盖（安全：避免长期凭据硬编码在配置文件中）
-	// 先读取项目专属变量，再让 AWS 标准变量覆盖，便于 IAM role / IRSA 等 AWS 原生工作流
-	StringEnv(&c.S3.AccessKeyID, "TS_S3_ACCESS_KEY_ID")
-	StringEnv(&c.S3.SecretAccessKey, "TS_S3_SECRET_ACCESS_KEY")
+	// 优先级遵循"越具体越优先"：YAML → AWS 通用变量 → TS_ 项目专属变量。
+	// AWS_* 提供 IRSA / IAM role 工作流的零配置兜底；TS_S3_* 表达对本应用的显式意图，
+	// 最后写入故胜出，避免宿主机上无关的 AWS 凭据静默覆盖到 R2 / B2 / MinIO 等非 AWS 部署。
 	StringEnv(&c.S3.AccessKeyID, "AWS_ACCESS_KEY_ID")
 	StringEnv(&c.S3.SecretAccessKey, "AWS_SECRET_ACCESS_KEY")
+	StringEnv(&c.S3.AccessKeyID, "TS_S3_ACCESS_KEY_ID")
+	StringEnv(&c.S3.SecretAccessKey, "TS_S3_SECRET_ACCESS_KEY")
 
 	//#################### 短信服务 ####################
 	c.SMSCode = c.getString("smsCode", c.SMSCode)

--- a/config/config_s3_test.go
+++ b/config/config_s3_test.go
@@ -95,19 +95,29 @@ s3:
 			wantSecret: "aws-secret",
 		},
 		{
-			name: "AWS standard env wins over TS_ prefixed env",
+			name: "TS_ prefixed env wins over AWS standard env",
 			envs: map[string]string{
 				"TS_S3_ACCESS_KEY_ID":     "ts-id",
 				"TS_S3_SECRET_ACCESS_KEY": "ts-secret",
 				"AWS_ACCESS_KEY_ID":       "aws-id",
 				"AWS_SECRET_ACCESS_KEY":   "aws-secret",
 			},
-			wantID:     "aws-id",
-			wantSecret: "aws-secret",
+			wantID:     "ts-id",
+			wantSecret: "ts-secret",
 		},
+	}
+	credEnvs := []string{
+		"TS_S3_ACCESS_KEY_ID",
+		"TS_S3_SECRET_ACCESS_KEY",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// 清空所有相关 env，避免宿主机/CI runner 上的真实凭据污染断言
+			for _, k := range credEnvs {
+				t.Setenv(k, "")
+			}
 			for k, v := range tt.envs {
 				t.Setenv(k, v)
 			}

--- a/config/config_s3_test.go
+++ b/config/config_s3_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestS3Defaults(t *testing.T) {
+	cfg := New()
+	vp := viper.New()
+	cfg.ConfigureWithViper(vp)
+
+	if cfg.S3.Endpoint != "" {
+		t.Errorf("S3.Endpoint default should be empty, got %q", cfg.S3.Endpoint)
+	}
+	if cfg.S3.Region != "" {
+		t.Errorf("S3.Region default should be empty, got %q", cfg.S3.Region)
+	}
+	if cfg.S3.Bucket != "" {
+		t.Errorf("S3.Bucket default should be empty, got %q", cfg.S3.Bucket)
+	}
+	if cfg.S3.UsePathStyle {
+		t.Errorf("S3.UsePathStyle default should be false, got true")
+	}
+}
+
+func TestS3FromViper(t *testing.T) {
+	const yaml = `
+s3:
+  endpoint: s3.us-west-2.amazonaws.com
+  region: us-west-2
+  bucket: my-bucket
+  accessKeyID: AKIAEXAMPLE
+  secretAccessKey: secret
+  bucketURL: https://my-bucket.s3.us-west-2.amazonaws.com
+  prefix: prod/
+  usePathStyle: true
+`
+	vp := viper.New()
+	vp.SetConfigType("yaml")
+	if err := vp.ReadConfig(strings.NewReader(yaml)); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	cfg := New()
+	cfg.ConfigureWithViper(vp)
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Endpoint", cfg.S3.Endpoint, "s3.us-west-2.amazonaws.com"},
+		{"Region", cfg.S3.Region, "us-west-2"},
+		{"Bucket", cfg.S3.Bucket, "my-bucket"},
+		{"AccessKeyID", cfg.S3.AccessKeyID, "AKIAEXAMPLE"},
+		{"SecretAccessKey", cfg.S3.SecretAccessKey, "secret"},
+		{"BucketURL", cfg.S3.BucketURL, "https://my-bucket.s3.us-west-2.amazonaws.com"},
+		{"Prefix", cfg.S3.Prefix, "prod/"},
+	}
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Errorf("S3.%s = %q, want %q", tt.name, tt.got, tt.want)
+		}
+	}
+	if !cfg.S3.UsePathStyle {
+		t.Errorf("expected S3.UsePathStyle=true")
+	}
+}

--- a/config/config_s3_test.go
+++ b/config/config_s3_test.go
@@ -69,3 +69,61 @@ s3:
 		t.Errorf("expected S3.UsePathStyle=true")
 	}
 }
+
+func TestS3CredentialsFromEnv(t *testing.T) {
+	const yaml = `
+s3:
+  accessKeyID: from-yaml-id
+  secretAccessKey: from-yaml-secret
+`
+	tests := []struct {
+		name       string
+		envs       map[string]string
+		wantID     string
+		wantSecret string
+	}{
+		{
+			name:       "TS_ prefixed env overrides YAML",
+			envs:       map[string]string{"TS_S3_ACCESS_KEY_ID": "ts-id", "TS_S3_SECRET_ACCESS_KEY": "ts-secret"},
+			wantID:     "ts-id",
+			wantSecret: "ts-secret",
+		},
+		{
+			name:       "AWS standard env overrides YAML",
+			envs:       map[string]string{"AWS_ACCESS_KEY_ID": "aws-id", "AWS_SECRET_ACCESS_KEY": "aws-secret"},
+			wantID:     "aws-id",
+			wantSecret: "aws-secret",
+		},
+		{
+			name: "AWS standard env wins over TS_ prefixed env",
+			envs: map[string]string{
+				"TS_S3_ACCESS_KEY_ID":     "ts-id",
+				"TS_S3_SECRET_ACCESS_KEY": "ts-secret",
+				"AWS_ACCESS_KEY_ID":       "aws-id",
+				"AWS_SECRET_ACCESS_KEY":   "aws-secret",
+			},
+			wantID:     "aws-id",
+			wantSecret: "aws-secret",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+			vp := viper.New()
+			vp.SetConfigType("yaml")
+			if err := vp.ReadConfig(strings.NewReader(yaml)); err != nil {
+				t.Fatalf("read config: %v", err)
+			}
+			cfg := New()
+			cfg.ConfigureWithViper(vp)
+			if cfg.S3.AccessKeyID != tt.wantID {
+				t.Errorf("S3.AccessKeyID = %q, want %q", cfg.S3.AccessKeyID, tt.wantID)
+			}
+			if cfg.S3.SecretAccessKey != tt.wantSecret {
+				t.Errorf("S3.SecretAccessKey = %q, want %q", cfg.S3.SecretAccessKey, tt.wantSecret)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `S3Config` struct for generic S3 / S3-compatible object storage (AWS S3, Cloudflare R2, Backblaze B2, Wasabi, MinIO with custom endpoints).
- Wire `s3.*` Viper bindings in `ConfigureWithViper` following the existing per-field pattern used for `MinioConfig` / `COSConfig`.
- Additive only — `MinioConfig` and `COSConfig` untouched; zero-value `S3` is inert.

Closes #38. This is the prerequisite for a follow-up `octo-server` PR that introduces an `awsS3` `fileService` and consolidates SigV4 / presigned-URL handling.

## Test plan

- [x] `go test -race ./config/ -run TestS3` passes (defaults + viper-driven population)
- [ ] Reviewer to confirm field naming choices flagged in the issue (`BucketURL` vs `DownloadURL`, default `UsePathStyle=false`, no `Region` validation here)