### PR TITLE
feat: add check-sprint-on-merge workflow

### DIFF
--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -1,0 +1,24 @@
+# Calls the org-level reusable workflow to block merge when the PR's
+# Sprint field on the Octo Board is missing or doesn't match the
+# current sprint iteration.
+#
+# Uses pull_request_target so the workflow can access secrets for the
+# Projects API. No code from the PR is checked out or executed.
+
+name: Check Sprint
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  check-sprint:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      repo-name: ${{ github.repository }}
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a caller workflow that invokes the org-level reusable `check-sprint` workflow on every PR to `main`.

Merges will be **blocked** if the PR's Sprint field on the [Octo Board](https://github.com/orgs/Mininglamp-OSS/projects/2) is not set to the current sprint iteration.

See [Mininglamp-OSS/.github #42](https://github.com/Mininglamp-OSS/.github/pull/42) for the reusable workflow implementation.

> **Note for deployer:** Enable the required status check `check-sprint / check-sprint` on the `main` branch protection *after* this PR is merged.