### PR TITLE
fix: align issue template + release-drafter labels with type:* naming convention

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug to help us improve
 title: "[bug] "
-labels: bug
+labels: type:bug
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for OCTO
 title: "[feature] "
-labels: enhancement
+labels: type:feature
 assignees: ''
 ---
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,12 +9,12 @@ template: |
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
   - title: "Features"
-    labels: [enhancement, feature]
+    labels: [type:feature]
   - title: "Bug Fixes"
-    labels: [bug, fix]
+    labels: [type:bug]
   - title: "CI and Infrastructure"
-    labels: [ci, infra, dependencies-changed, dependencies]
+    labels: [type:chore, dependencies-changed]
   - title: "Documentation"
-    labels: [documentation, docs]
+    labels: [type:docs]
 exclude-labels: [skip-changelog]
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,12 +9,12 @@ template: |
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
   - title: "Features"
-    labels: [type:feature]
+    labels: ["type:feature"]
   - title: "Bug Fixes"
-    labels: [type:bug]
+    labels: ["type:bug"]
   - title: "CI and Infrastructure"
-    labels: [type:chore, dependencies-changed]
+    labels: ["type:chore", dependencies-changed, dependencies]
   - title: "Documentation"
-    labels: [type:docs]
+    labels: ["type:docs"]
 exclude-labels: [skip-changelog]
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"


### PR DESCRIPTION
## Problem

1. Issue templates (`bug_report.md`, `feature_request.md`) reference bare labels (`bug`, `enhancement`) that do not exist on this repo. The actual labels use `type:bug` / `type:feature`.
2. `release-drafter.yml` has the same label mismatch.

Result: issues are created without type labels, and PRs are not categorized in release notes.

## Fix

- `bug_report.md`: `labels: bug` → `labels: type:bug`
- `feature_request.md`: `labels: enhancement` → `labels: type:feature`
- `release-drafter.yml`: all label references updated to `type:*` scheme

## Context

Part of org-wide label scheme alignment.