### PR TITLE
feat(config): refine S3Config — DownloadURL rename + SessionToken

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -655,7 +655,8 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	c.S3.Bucket = c.getString("s3.bucket", c.S3.Bucket)
 	c.S3.AccessKeyID = c.getString("s3.accessKeyID", c.S3.AccessKeyID)
 	c.S3.SecretAccessKey = c.getString("s3.secretAccessKey", c.S3.SecretAccessKey)
-	c.S3.BucketURL = c.getString("s3.bucketURL", c.S3.BucketURL)
+	c.S3.SessionToken = c.getString("s3.sessionToken", c.S3.SessionToken)
+	c.S3.DownloadURL = c.getString("s3.downloadURL", c.S3.DownloadURL)
 	c.S3.Prefix = c.getString("s3.prefix", c.S3.Prefix)
 	c.S3.UsePathStyle = c.getBool("s3.usePathStyle", c.S3.UsePathStyle)
 	// 环境变量覆盖（安全：避免长期凭据硬编码在配置文件中）
@@ -664,8 +665,10 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	// 最后写入故胜出，避免宿主机上无关的 AWS 凭据静默覆盖到 R2 / B2 / MinIO 等非 AWS 部署。
 	StringEnv(&c.S3.AccessKeyID, "AWS_ACCESS_KEY_ID")
 	StringEnv(&c.S3.SecretAccessKey, "AWS_SECRET_ACCESS_KEY")
+	StringEnv(&c.S3.SessionToken, "AWS_SESSION_TOKEN")
 	StringEnv(&c.S3.AccessKeyID, "TS_S3_ACCESS_KEY_ID")
 	StringEnv(&c.S3.SecretAccessKey, "TS_S3_SECRET_ACCESS_KEY")
+	StringEnv(&c.S3.SessionToken, "TS_S3_SESSION_TOKEN")
 
 	//#################### 短信服务 ####################
 	c.SMSCode = c.getString("smsCode", c.SMSCode)
@@ -1102,11 +1105,34 @@ type S3Config struct {
 	AccessKeyID     string
 	SecretAccessKey string
 
-	// BucketURL, when set, overrides the URL returned by DownloadURL and
-	// signed against by presigned GET/PUT. Use this for CDN-fronted
-	// buckets or custom domains. Must be scheme://host[:port] with no
-	// path component (same contract as MinioConfig.DownloadURL).
-	BucketURL string
+	// SessionToken is the AWS STS session token for temporary credentials.
+	// Empty for long-lived IAM user keys; populated by IRSA / IMDSv2 /
+	// EKS Pod Identity / AWS SSO workflows that issue rotating credentials.
+	//
+	// Lifecycle: the service layer does NOT refresh the token itself — the
+	// deployment pipeline is responsible for refreshing AWS_SESSION_TOKEN
+	// (and the paired key/secret) before STS expiry. Leave empty for
+	// static credentials.
+	SessionToken string
+
+	// DownloadURL is the browser-facing base URL used for unsigned object
+	// access (e.g. preview redirects, upload-response `path` field). It
+	// does NOT participate in SigV4 signing — presigned PUT/GET URLs are
+	// always signed against Endpoint.
+	//
+	// Use cases:
+	//   - Empty: callers fall back to the canonical hostname constructed
+	//     from Endpoint + Bucket.
+	//   - CloudFront / CDN front-door: set to the distribution URL, e.g.
+	//     https://d123.cloudfront.net. The browser fetches reads via
+	//     CloudFront (typically with OAC for private buckets); presigned
+	//     PUT/GET still flow directly to S3.
+	//   - Custom domain: set to a bucket-subdomain custom domain, e.g.
+	//     https://my-bucket.cdn.example.com.
+	//
+	// Must be scheme://host[:port] with no path component (same contract
+	// as MinioConfig.DownloadURL).
+	DownloadURL string
 
 	// Prefix is an optional object-key prefix for multi-environment
 	// isolation (e.g. "staging/" or "prod/"). Mirrors COSConfig.Prefix.

--- a/config/config.go
+++ b/config/config.go
@@ -1113,6 +1113,10 @@ type S3Config struct {
 	// deployment pipeline is responsible for refreshing AWS_SESSION_TOKEN
 	// (and the paired key/secret) before STS expiry. Leave empty for
 	// static credentials.
+	//
+	// Override precedence: YAML s3.sessionToken → AWS_SESSION_TOKEN →
+	// TS_S3_SESSION_TOKEN (project-prefixed wins). Same pattern as the
+	// AccessKeyID / SecretAccessKey pair.
 	SessionToken string
 
 	// DownloadURL is the browser-facing base URL used for unsigned object

--- a/config/config_s3_test.go
+++ b/config/config_s3_test.go
@@ -34,7 +34,8 @@ s3:
   bucket: my-bucket
   accessKeyID: AKIAEXAMPLE
   secretAccessKey: secret
-  bucketURL: https://my-bucket.s3.us-west-2.amazonaws.com
+  sessionToken: FwoGZXIvYXdzEXAMPLE
+  downloadURL: https://d123.cloudfront.net
   prefix: prod/
   usePathStyle: true
 `
@@ -57,7 +58,8 @@ s3:
 		{"Bucket", cfg.S3.Bucket, "my-bucket"},
 		{"AccessKeyID", cfg.S3.AccessKeyID, "AKIAEXAMPLE"},
 		{"SecretAccessKey", cfg.S3.SecretAccessKey, "secret"},
-		{"BucketURL", cfg.S3.BucketURL, "https://my-bucket.s3.us-west-2.amazonaws.com"},
+		{"SessionToken", cfg.S3.SessionToken, "FwoGZXIvYXdzEXAMPLE"},
+		{"DownloadURL", cfg.S3.DownloadURL, "https://d123.cloudfront.net"},
 		{"Prefix", cfg.S3.Prefix, "prod/"},
 	}
 	for _, tt := range tests {
@@ -75,42 +77,59 @@ func TestS3CredentialsFromEnv(t *testing.T) {
 s3:
   accessKeyID: from-yaml-id
   secretAccessKey: from-yaml-secret
+  sessionToken: from-yaml-token
 `
 	tests := []struct {
-		name       string
-		envs       map[string]string
-		wantID     string
-		wantSecret string
+		name      string
+		envs      map[string]string
+		wantID    string
+		wantSec   string
+		wantToken string
 	}{
 		{
-			name:       "TS_ prefixed env overrides YAML",
-			envs:       map[string]string{"TS_S3_ACCESS_KEY_ID": "ts-id", "TS_S3_SECRET_ACCESS_KEY": "ts-secret"},
-			wantID:     "ts-id",
-			wantSecret: "ts-secret",
+			name: "TS_ prefixed env overrides YAML",
+			envs: map[string]string{
+				"TS_S3_ACCESS_KEY_ID":     "ts-id",
+				"TS_S3_SECRET_ACCESS_KEY": "ts-secret",
+				"TS_S3_SESSION_TOKEN":     "ts-token",
+			},
+			wantID:    "ts-id",
+			wantSec:   "ts-secret",
+			wantToken: "ts-token",
 		},
 		{
-			name:       "AWS standard env overrides YAML",
-			envs:       map[string]string{"AWS_ACCESS_KEY_ID": "aws-id", "AWS_SECRET_ACCESS_KEY": "aws-secret"},
-			wantID:     "aws-id",
-			wantSecret: "aws-secret",
+			name: "AWS standard env overrides YAML",
+			envs: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "aws-id",
+				"AWS_SECRET_ACCESS_KEY": "aws-secret",
+				"AWS_SESSION_TOKEN":     "aws-token",
+			},
+			wantID:    "aws-id",
+			wantSec:   "aws-secret",
+			wantToken: "aws-token",
 		},
 		{
 			name: "TS_ prefixed env wins over AWS standard env",
 			envs: map[string]string{
 				"TS_S3_ACCESS_KEY_ID":     "ts-id",
 				"TS_S3_SECRET_ACCESS_KEY": "ts-secret",
+				"TS_S3_SESSION_TOKEN":     "ts-token",
 				"AWS_ACCESS_KEY_ID":       "aws-id",
 				"AWS_SECRET_ACCESS_KEY":   "aws-secret",
+				"AWS_SESSION_TOKEN":       "aws-token",
 			},
-			wantID:     "ts-id",
-			wantSecret: "ts-secret",
+			wantID:    "ts-id",
+			wantSec:   "ts-secret",
+			wantToken: "ts-token",
 		},
 	}
 	credEnvs := []string{
 		"TS_S3_ACCESS_KEY_ID",
 		"TS_S3_SECRET_ACCESS_KEY",
+		"TS_S3_SESSION_TOKEN",
 		"AWS_ACCESS_KEY_ID",
 		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -131,8 +150,11 @@ s3:
 			if cfg.S3.AccessKeyID != tt.wantID {
 				t.Errorf("S3.AccessKeyID = %q, want %q", cfg.S3.AccessKeyID, tt.wantID)
 			}
-			if cfg.S3.SecretAccessKey != tt.wantSecret {
-				t.Errorf("S3.SecretAccessKey = %q, want %q", cfg.S3.SecretAccessKey, tt.wantSecret)
+			if cfg.S3.SecretAccessKey != tt.wantSec {
+				t.Errorf("S3.SecretAccessKey = %q, want %q", cfg.S3.SecretAccessKey, tt.wantSec)
+			}
+			if cfg.S3.SessionToken != tt.wantToken {
+				t.Errorf("S3.SessionToken = %q, want %q", cfg.S3.SessionToken, tt.wantToken)
 			}
 		})
 	}

--- a/config/config_s3_test.go
+++ b/config/config_s3_test.go
@@ -72,6 +72,27 @@ s3:
 	}
 }
 
+// TestS3LegacyBucketURLNotRead locks in the clean break from issue #42:
+// the deprecated `s3.bucketURL` viper key must not populate the renamed
+// `DownloadURL` field. If a future change reintroduces a fallback alias,
+// this test will fail and force an explicit decision.
+func TestS3LegacyBucketURLNotRead(t *testing.T) {
+	const yaml = `
+s3:
+  bucketURL: https://legacy.example.com
+`
+	vp := viper.New()
+	vp.SetConfigType("yaml")
+	if err := vp.ReadConfig(strings.NewReader(yaml)); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfg := New()
+	cfg.ConfigureWithViper(vp)
+	if cfg.S3.DownloadURL != "" {
+		t.Errorf("legacy s3.bucketURL must not populate DownloadURL; got %q", cfg.S3.DownloadURL)
+	}
+}
+
 func TestS3CredentialsFromEnv(t *testing.T) {
 	const yaml = `
 s3:
@@ -86,6 +107,13 @@ s3:
 		wantSec   string
 		wantToken string
 	}{
+		{
+			name:      "no env vars — YAML wins",
+			envs:      nil,
+			wantID:    "from-yaml-id",
+			wantSec:   "from-yaml-secret",
+			wantToken: "from-yaml-token",
+		},
 		{
 			name: "TS_ prefixed env overrides YAML",
 			envs: map[string]string{


### PR DESCRIPTION
Closes #42.

## Summary

- Rename `S3Config.BucketURL` → `DownloadURL`; pin godoc contract to "never participates in SigV4 signing" so presigned PUT/GET always sign against `Endpoint`. Mirrors `MinioConfig.DownloadURL`.
- Add `S3Config.SessionToken` for STS / IRSA / IMDSv2 / EKS Pod Identity / AWS SSO. Wires both `AWS_SESSION_TOKEN` and `TS_S3_SESSION_TOKEN` with the same precedence as the existing key/secret pair (YAML → AWS_* → TS_S3_* wins).
- Viper keys: `s3.bucketURL` → `s3.downloadURL` (clean break, no alias); add `s3.sessionToken`.

## Why no deprecation alias

`S3Config` landed 2 days ago (`72ee710`, 2026-05-23). No `octo-lib` consumer reads it yet — the only known downstream is octo-server PR #147, which is not merged and will be synced in the matching PR. A clean break now avoids the "deprecated alias maintained forever" tax.

## Why the rename matters

The previous godoc explicitly said BucketURL is "signed against by presigned GET/PUT". Combined with its role as the unsigned browser URL, setting it to a CloudFront distribution produces `SignatureDoesNotMatch` on AWS S3 (canonical request expects the bucket-addressed S3 hostname). `DownloadURL` makes the single responsibility enforceable: it is only ever read by `publicURL` / `DownloadURL`-shaped helpers; presigned URLs always sign against `Endpoint`. To deploy CloudFront/OAC, operators set `DownloadURL` to the distribution URL and `Endpoint` to the canonical S3 API host.

## Out of scope (deferred per issue #42)

`Insecure`, `RequestTimeout`, `CABundle`, Transfer Acceleration, multi-region endpoint pairs.

## Test plan

- [x] `go test -race ./config/...` passes
- [x] `TestS3FromViper` updated for new YAML key + asserts SessionToken/DownloadURL
- [x] `TestS3CredentialsFromEnv` extended with SessionToken precedence cases (TS_ wins over AWS_*)
- [ ] octo-server PR #147 follow-up to consume new field names and pass `SessionToken` into `credentials.NewStaticV4`