### PR TITLE
fix(config): add integer conversion safety checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -878,19 +878,31 @@ func (c *Config) GetAvatarPath(uid string) string {
 
 // GetGroupAvatarFilePath 获取群头像上传路径
 func (c *Config) GetGroupAvatarFilePath(groupNo string) string {
-	avatarID := crc32.ChecksumIEEE([]byte(groupNo)) % uint32(c.Avatar.Partition)
+	partition := c.Avatar.Partition
+	if partition <= 0 {
+		partition = 1
+	}
+	avatarID := crc32.ChecksumIEEE([]byte(groupNo)) % uint32(partition)
 	return fmt.Sprintf("group/%d/%s.png", avatarID, groupNo)
 }
 
 // GetCommunityAvatarFilePath 获取社区头像上传路径
 func (c *Config) GetCommunityAvatarFilePath(communityNo string) string {
-	avatarID := crc32.ChecksumIEEE([]byte(communityNo)) % uint32(c.Avatar.Partition)
+	partition := c.Avatar.Partition
+	if partition <= 0 {
+		partition = 1
+	}
+	avatarID := crc32.ChecksumIEEE([]byte(communityNo)) % uint32(partition)
 	return fmt.Sprintf("community/%d/%s.png", avatarID, communityNo)
 }
 
 // GetCommunityCoverFilePath 获取社区封面上传路径
 func (c *Config) GetCommunityCoverFilePath(communityNo string) string {
-	avatarID := crc32.ChecksumIEEE([]byte(communityNo)) % uint32(c.Avatar.Partition)
+	partition := c.Avatar.Partition
+	if partition <= 0 {
+		partition = 1
+	}
+	avatarID := crc32.ChecksumIEEE([]byte(communityNo)) % uint32(partition)
 	return fmt.Sprintf("community/%d/%s_cover.png", avatarID, communityNo)
 }
 
@@ -975,7 +987,7 @@ func GetEnvInt(key string, defaultValue int) int {
 	if strings.TrimSpace(v) == "" {
 		return defaultValue
 	}
-	i, err := strconv.ParseInt(v, 10, 64)
+	i, err := strconv.ParseInt(v, 10, 0)
 	if err != nil {
 		fmt.Printf("WARN: invalid env %s=%q, using default %d: %v\n", key, v, defaultValue, err)
 		return defaultValue

--- a/config/msg.go
+++ b/config/msg.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 
@@ -155,6 +156,9 @@ func (c *Context) SendMessageWithResult(req *MsgSendReq) (*MsgSendResp, error) {
 		messageID := dataResult.Get("message_id").Int()
 		messageSeq := dataResult.Get("message_seq").Int()
 		clientMsgNo := dataResult.Get("client_msg_no").String()
+		if messageSeq < 0 || messageSeq > math.MaxUint32 {
+			return nil, fmt.Errorf("IM服务[SendMessage]返回 message_seq=%d 超出 uint32 范围", messageSeq)
+		}
 		return &MsgSendResp{
 			MessageID:   messageID,
 			MessageSeq:  uint32(messageSeq),


### PR DESCRIPTION
## Summary

Fix CodeQL-reported integer conversion issues in `config/` package (GO-S1040).

### Changes

**1. `GetEnvInt` — `config.go:978`**
- Changed `strconv.ParseInt(v, 10, 64)` → `strconv.ParseInt(v, 10, 0)`
- `bitSize=0` validates against platform `int` width, making the subsequent `int(i)` always safe
- On 64-bit: accepts full int64 range. On 32-bit: rejects values > `math.MaxInt32`

**2. `SendMessageWithResult` — `msg.go:160`**
- Added bounds check before `uint32(messageSeq)` cast
- Returns explicit error if WuKongIM returns `message_seq` outside `[0, math.MaxUint32]`
- Prevents silent truncation that could cause message ordering/dedup issues

**3. Avatar path functions — `config.go:881/887/893`**
- `GetGroupAvatarFilePath`, `GetCommunityAvatarFilePath`, `GetCommunityCoverFilePath`
- Guard `Avatar.Partition` against non-positive values (fallback to 1)
- Prevents `uint32` wrap on negative config values and division-by-zero on zero

### Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./config/...` ✅

### Not changed (false positives)
- `zapcore.Level → int` (int8 underlying, always safe)
- `seqStep int64 → int` (hardcoded constant 1000, always safe)
- `GetContentType int64 → int` (enum values, always within range)