### PR TITLE
feat(octo-lib): 图文混排 RichText=14 blocks schema + 跨端契约 (Phase 0)

### DIFF
--- a/common/richtext.go
+++ b/common/richtext.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/json"
 	"errors"
+	"net/url"
 	"strings"
 )
 
@@ -37,12 +38,25 @@ const RichTextMaxPayloadBytes = 1 << 20
 var (
 	// ErrRichTextPayloadTooLarge payload 序列化后超过 1MB 上限。
 	ErrRichTextPayloadTooLarge = errors.New("richtext payload 超过 1MB 上限")
+	// ErrRichTextEmptyContent 顶层 content 缺失 / null / 空数组（契约必填且非空）。
+	ErrRichTextEmptyContent = errors.New("richtext content 必填且不能为空数组")
 	// ErrRichTextUnknownBlock content 中出现未知 block 类型。
 	ErrRichTextUnknownBlock = errors.New("richtext 未知 block 类型")
+	// ErrRichTextTextEmpty text block 的 text 字段缺失/为空（契约必填）。
+	ErrRichTextTextEmpty = errors.New("richtext text block 的 text 必填且不能为空")
 	// ErrRichTextImageNoURL image block 缺少 url。
 	ErrRichTextImageNoURL = errors.New("richtext image block 缺少 url")
-	// ErrRichTextImageBase64 image block 内嵌了 base64（data: URI），仅接受 url 引用。
-	ErrRichTextImageBase64 = errors.New("richtext image block 禁止内嵌 base64，只接受 url 引用")
+	// ErrRichTextImageBadScheme image block 的 url scheme 不在 allowlist（仅 http/https）。
+	// 也覆盖内嵌 data: URI —— data:/javascript:/file: 等一律拒绝。
+	ErrRichTextImageBadScheme = errors.New("richtext image block 的 url 只接受 http/https scheme")
+	// ErrRichTextImageNoSize image block 缺少 width/height 或其值非正（契约必填且 >0）。
+	ErrRichTextImageNoSize = errors.New("richtext image block 的 width/height 必填且必须 >0")
+
+	// ErrRichTextImageBase64 已废弃：保留以兼容老调用方的 errors.Is 比较。
+	// 新代码统一返回 ErrRichTextImageBadScheme（scheme allowlist 覆盖 data: URI）。
+	//
+	// Deprecated: 使用 ErrRichTextImageBadScheme。
+	ErrRichTextImageBase64 = ErrRichTextImageBadScheme
 )
 
 // RichTextBlock 是 content 数组中的单个元素。
@@ -57,11 +71,11 @@ type RichTextBlock struct {
 	Text string `json:"text,omitempty"`
 
 	// ---- image block ----
-	// URL 图片引用地址（禁止 data: base64）。
+	// URL 图片引用地址（scheme allowlist：仅 http/https；禁 data:/javascript:/file: 等）。
 	URL string `json:"url,omitempty"`
-	// Width 图片宽度（像素）。
+	// Width 图片宽度（像素，必填且 >0，供端上占位排版避免抖动）。
 	Width int `json:"width,omitempty"`
-	// Height 图片高度（像素）。
+	// Height 图片高度（像素，必填且 >0）。
 	Height int `json:"height,omitempty"`
 	// Size 图片字节大小（可选）。
 	Size int `json:"size,omitempty"`
@@ -138,24 +152,55 @@ func BuildRichTextPlain(content []RichTextBlock) string {
 
 // FillPlain 由 server 调用：用 Content 重新生成 plain 并回填（server 权威，
 // 不信任端上送的 plain），返回最终 plain。
+//
+// 注意：FillPlain 只重算 plain，不做大小复检。注入的 [图片] 占位符可能使
+// payload 序列化后撑过 1MB（入站过校验 → 出站超限）。server 入库出口应改用
+// FillPlainBounded，对回填后的整体 payload 复检大小。
 func (p *RichTextPayload) FillPlain() string {
 	p.Plain = BuildRichTextPlain(p.Content)
 	return p.Plain
 }
 
-// ValidateRichTextBlocks 校验 block 数组：type 必须是已知枚举；image block
-// 必带 url 且禁止内嵌 base64（data: URI）。
+// FillPlainBounded 是 server 入库出口的权威路径：先 FillPlain 重算 plain，再对
+// 回填后的整条 payload 复检序列化大小，避免 server 自己的 plain 注入把 payload
+// 撑过 RichTextMaxPayloadBytes（1MB）——入站校验只看原始字节，不含 server 后写的
+// plain，故必须在 FillPlain 之后再复检一次。超限返回 ErrRichTextPayloadTooLarge。
+func (p *RichTextPayload) FillPlainBounded() (string, error) {
+	plain := p.FillPlain()
+	out, err := json.Marshal(p)
+	if err != nil {
+		return plain, err
+	}
+	if len(out) > RichTextMaxPayloadBytes {
+		return plain, ErrRichTextPayloadTooLarge
+	}
+	return plain, nil
+}
+
+// ValidateRichTextBlocks 校验 block 数组（写入/发送端：write-strict）：
+//   - 每个 block 的 type 必须是已知枚举（text/image），未知 type 拒绝；
+//   - text block：text 必填且非空（契约 §1.3）；
+//   - image block：url 必填、scheme 仅允许 http/https（拒 data:/javascript:/file:
+//     等一切其它 scheme，契约 §1.4 + §3）、width/height 必填且 >0（契约 §1.4）。
+//
+// 写入端严格（本函数），展示/解析端宽容（BuildRichTextPlain 对未知 type 降级，
+// 见契约 §5.3 Postel）。空 content 由 ValidateRichTextPayload 统一拦截。
 func ValidateRichTextBlocks(content []RichTextBlock) error {
 	for _, blk := range content {
 		switch blk.Type {
 		case RichTextBlockText:
-			// 纯文本，无强约束。
+			if strings.TrimSpace(blk.Text) == "" {
+				return ErrRichTextTextEmpty
+			}
 		case RichTextBlockImage:
 			if strings.TrimSpace(blk.URL) == "" {
 				return ErrRichTextImageNoURL
 			}
-			if isBase64DataURI(blk.URL) {
-				return ErrRichTextImageBase64
+			if !isAllowedImageURLScheme(blk.URL) {
+				return ErrRichTextImageBadScheme
+			}
+			if blk.Width <= 0 || blk.Height <= 0 {
+				return ErrRichTextImageNoSize
 			}
 		default:
 			return ErrRichTextUnknownBlock
@@ -164,12 +209,14 @@ func ValidateRichTextBlocks(content []RichTextBlock) error {
 	return nil
 }
 
-// ValidateRichTextPayload 校验序列化后的 RichText payload：
-//  1. 大小不超过 RichTextMaxPayloadBytes；
+// ValidateRichTextPayload 校验序列化后的 RichText payload（写入/发送端 gate）：
+//  1. 大小不超过 RichTextMaxPayloadBytes（仅原始入站字节；server 注入 plain 后
+//     的复检见 FillPlainBounded）；
 //  2. 可解析（兼容老的字符串 content，不崩）；
-//  3. block 结构合法。
+//  3. 顶层 content 必填且非空（拒 content 缺失 / null / 空数组，契约 §1.1）；
+//  4. 每个 block 结构合法（见 ValidateRichTextBlocks）。
 //
-// 校验通过后返回解析好的 payload，供调用方直接复用（如 FillPlain）。
+// 校验通过后返回解析好的 payload，供调用方直接复用（如 FillPlainBounded）。
 func ValidateRichTextPayload(data []byte) (*RichTextPayload, error) {
 	if len(data) > RichTextMaxPayloadBytes {
 		return nil, ErrRichTextPayloadTooLarge
@@ -178,21 +225,42 @@ func ValidateRichTextPayload(data []byte) (*RichTextPayload, error) {
 	if err := json.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
+	if len(p.Content) == 0 {
+		return nil, ErrRichTextEmptyContent
+	}
 	if err := ValidateRichTextBlocks(p.Content); err != nil {
 		return nil, err
 	}
 	return &p, nil
 }
 
-// isBase64DataURI 判断 url 是否为内嵌 data: URI（base64 内联），用于禁内嵌图片。
-func isBase64DataURI(url string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(url)), "data:")
+// isAllowedImageURLScheme 判断 image url 的 scheme 是否在 allowlist（仅 http/https）。
+// 取代旧的「仅挡 data:」策略：scheme allowlist 同时拦下 data:/javascript:/vbscript:/
+// file: 等一切非 http(s) scheme（契约 §1.4 + §3）。无 scheme 的相对地址也拒绝。
+func isAllowedImageURLScheme(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return true
+	default:
+		return false
+	}
 }
 
 // GetRichTextDisplayText 给定 RichText(=14) payload，返回用于展示/摘要的纯文本：
 //   - 优先用 payload 内的 plain（server 已生成）；
-//   - plain 为空则现场遍历 content 生成（兼容老字符串 content）；
+//   - plain 为空（含纯空白）则现场遍历 content 生成（兼容老字符串 content）；
 //   - 完全无法解析或为空时回退到 GetDisplayText(RichText)（"富文本消息"）。
+//
+// ⚠️ 信任边界（契约 §2：端上送的 plain 不可信）：
+//   - 本函数走「存储后展示路径」——它信任 plain，前提是 payload 已在入库出口
+//     经 (*RichTextPayload).FillPlainBounded() / FillPlain() 用 content 重算覆盖。
+//     对已落库、server 权威生成 plain 的 payload，本函数是正确且高效的展示入口。
+//   - 「入站校验路径」严禁用本函数判定内容：入站请先 ValidateRichTextPayload，
+//     再 FillPlainBounded 重建 plain；不要直接展示端上送的原始 plain（可被伪造）。
 //
 // 这是对既有 GetDisplayText 的补充：GetDisplayText 仅按 type 返回静态名称，
 // 不解析 payload；此函数在拿到 payload 时走 plain，且向后兼容。
@@ -204,7 +272,7 @@ func GetRichTextDisplayText(payload []byte) string {
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return GetDisplayText(RichText.Int())
 	}
-	if p.Plain != "" {
+	if strings.TrimSpace(p.Plain) != "" {
 		return p.Plain
 	}
 	if plain := BuildRichTextPlain(p.Content); plain != "" {

--- a/common/richtext.go
+++ b/common/richtext.go
@@ -1,0 +1,214 @@
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// RichText (ContentType=14) 图文混排 blocks payload schema。
+//
+// 设计基线（两轮跨端审计 YUJ-2740 / YUJ-2745 已定，勿推翻）：
+// 图文混排复用已有的 RichText=14（见 common/msg.go），不新增 ContentType。
+// 正文以 content 有序数组承载，数组顺序即图文穿插顺序。顶层 plain 为冗余纯
+// 文本，由 server 生成，供 search / 推送 / 摘要 / 复制 / 下游 LLM 复用。
+//
+// 命名约定（锁定，勿改）：字段名 content（block 数组）+ plain（纯文本）。
+// 禁止使用 entities + offset/length —— 库内已有多套同名异义 entities
+// （robot mention 的 Entitiy{Offset,Length}、其它端的 range 标注等），
+// 混用必错，务必避开。
+
+// RichText block 类型常量（显式枚举，二期富文本格式在此扩展）。
+const (
+	// RichTextBlockText 纯文本块。MVP 锁定 text=纯文本，不渲染 markdown。
+	RichTextBlockText = "text"
+	// RichTextBlockImage 图片块，只接受 url 引用。
+	RichTextBlockImage = "image"
+)
+
+// RichTextImagePlaceholder 生成 plain 时 image block 注入的占位符。
+const RichTextImagePlaceholder = "[图片]"
+
+// RichTextMaxPayloadBytes RichText payload 序列化后的硬上限（1MB）。
+// 图片只允许 url 引用，禁止内嵌 base64，以保证 payload 不超限。
+const RichTextMaxPayloadBytes = 1 << 20
+
+// RichText payload 校验错误。
+var (
+	// ErrRichTextPayloadTooLarge payload 序列化后超过 1MB 上限。
+	ErrRichTextPayloadTooLarge = errors.New("richtext payload 超过 1MB 上限")
+	// ErrRichTextUnknownBlock content 中出现未知 block 类型。
+	ErrRichTextUnknownBlock = errors.New("richtext 未知 block 类型")
+	// ErrRichTextImageNoURL image block 缺少 url。
+	ErrRichTextImageNoURL = errors.New("richtext image block 缺少 url")
+	// ErrRichTextImageBase64 image block 内嵌了 base64（data: URI），仅接受 url 引用。
+	ErrRichTextImageBase64 = errors.New("richtext image block 禁止内嵌 base64，只接受 url 引用")
+)
+
+// RichTextBlock 是 content 数组中的单个元素。
+//   - type=text  用 Text；
+//   - type=image 用 URL/Width/Height（Size、Name 可选）。
+type RichTextBlock struct {
+	// Type 块类型，取值见 RichTextBlockText / RichTextBlockImage。
+	Type string `json:"type"`
+
+	// ---- text block ----
+	// Text 文本内容（MVP：纯文本，不渲染 markdown）。
+	Text string `json:"text,omitempty"`
+
+	// ---- image block ----
+	// URL 图片引用地址（禁止 data: base64）。
+	URL string `json:"url,omitempty"`
+	// Width 图片宽度（像素）。
+	Width int `json:"width,omitempty"`
+	// Height 图片高度（像素）。
+	Height int `json:"height,omitempty"`
+	// Size 图片字节大小（可选）。
+	Size int `json:"size,omitempty"`
+	// Name 图片原始文件名（可选）。
+	Name string `json:"name,omitempty"`
+}
+
+// RichTextPayload 是 RichText(=14) 消息的 payload。
+//   - Content 为有序 block 数组，顺序即图文穿插顺序；
+//   - Plain 为冗余纯文本，契约上由 server 生成（见 FillPlain）。
+type RichTextPayload struct {
+	Content []RichTextBlock `json:"content"`
+	Plain   string          `json:"plain"`
+}
+
+// UnmarshalJSON 向后兼容老版本 content 为字符串的 RichText payload：
+//   - 老 payload {"content":"hello"} 解析为单个 text block，并在 plain 为空时
+//     回填为该字符串，保证老的字符串 content 路径不崩；
+//   - 新 payload {"content":[...]} 正常解析为 block 数组。
+func (p *RichTextPayload) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Content json.RawMessage `json:"content"`
+		Plain   string          `json:"plain"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	p.Plain = raw.Plain
+	p.Content = nil
+	if len(raw.Content) == 0 || string(raw.Content) == "null" {
+		return nil
+	}
+	// 优先按新结构（数组）解析。
+	var blocks []RichTextBlock
+	if err := json.Unmarshal(raw.Content, &blocks); err == nil {
+		p.Content = blocks
+		return nil
+	}
+	// 回退：老版本 content 是纯字符串。
+	var s string
+	if err := json.Unmarshal(raw.Content, &s); err != nil {
+		return err
+	}
+	p.Content = []RichTextBlock{{Type: RichTextBlockText, Text: s}}
+	if p.Plain == "" {
+		p.Plain = s
+	}
+	return nil
+}
+
+// BuildRichTextPlain 遍历 content blocks 生成纯文本：
+//   - text block 取 Text；
+//   - image block 注入 RichTextImagePlaceholder；
+//   - 数组顺序即拼接顺序。
+//
+// 契约上 plain 由 server 在入库出口生成，不是端的职责。
+func BuildRichTextPlain(content []RichTextBlock) string {
+	var b strings.Builder
+	for _, blk := range content {
+		switch blk.Type {
+		case RichTextBlockImage:
+			b.WriteString(RichTextImagePlaceholder)
+		case RichTextBlockText:
+			b.WriteString(blk.Text)
+		default:
+			// 未知类型（二期扩展前的前向兼容防御）：有 text 则写 text，否则跳过。
+			if blk.Text != "" {
+				b.WriteString(blk.Text)
+			}
+		}
+	}
+	return b.String()
+}
+
+// FillPlain 由 server 调用：用 Content 重新生成 plain 并回填（server 权威，
+// 不信任端上送的 plain），返回最终 plain。
+func (p *RichTextPayload) FillPlain() string {
+	p.Plain = BuildRichTextPlain(p.Content)
+	return p.Plain
+}
+
+// ValidateRichTextBlocks 校验 block 数组：type 必须是已知枚举；image block
+// 必带 url 且禁止内嵌 base64（data: URI）。
+func ValidateRichTextBlocks(content []RichTextBlock) error {
+	for _, blk := range content {
+		switch blk.Type {
+		case RichTextBlockText:
+			// 纯文本，无强约束。
+		case RichTextBlockImage:
+			if strings.TrimSpace(blk.URL) == "" {
+				return ErrRichTextImageNoURL
+			}
+			if isBase64DataURI(blk.URL) {
+				return ErrRichTextImageBase64
+			}
+		default:
+			return ErrRichTextUnknownBlock
+		}
+	}
+	return nil
+}
+
+// ValidateRichTextPayload 校验序列化后的 RichText payload：
+//  1. 大小不超过 RichTextMaxPayloadBytes；
+//  2. 可解析（兼容老的字符串 content，不崩）；
+//  3. block 结构合法。
+//
+// 校验通过后返回解析好的 payload，供调用方直接复用（如 FillPlain）。
+func ValidateRichTextPayload(data []byte) (*RichTextPayload, error) {
+	if len(data) > RichTextMaxPayloadBytes {
+		return nil, ErrRichTextPayloadTooLarge
+	}
+	var p RichTextPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	if err := ValidateRichTextBlocks(p.Content); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// isBase64DataURI 判断 url 是否为内嵌 data: URI（base64 内联），用于禁内嵌图片。
+func isBase64DataURI(url string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(url)), "data:")
+}
+
+// GetRichTextDisplayText 给定 RichText(=14) payload，返回用于展示/摘要的纯文本：
+//   - 优先用 payload 内的 plain（server 已生成）；
+//   - plain 为空则现场遍历 content 生成（兼容老字符串 content）；
+//   - 完全无法解析或为空时回退到 GetDisplayText(RichText)（"富文本消息"）。
+//
+// 这是对既有 GetDisplayText 的补充：GetDisplayText 仅按 type 返回静态名称，
+// 不解析 payload；此函数在拿到 payload 时走 plain，且向后兼容。
+func GetRichTextDisplayText(payload []byte) string {
+	if len(payload) == 0 {
+		return GetDisplayText(RichText.Int())
+	}
+	var p RichTextPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return GetDisplayText(RichText.Int())
+	}
+	if p.Plain != "" {
+		return p.Plain
+	}
+	if plain := BuildRichTextPlain(p.Content); plain != "" {
+		return plain
+	}
+	return GetDisplayText(RichText.Int())
+}

--- a/common/richtext.go
+++ b/common/richtext.go
@@ -234,9 +234,11 @@ func ValidateRichTextPayload(data []byte) (*RichTextPayload, error) {
 	return &p, nil
 }
 
-// isAllowedImageURLScheme 判断 image url 的 scheme 是否在 allowlist（仅 http/https）。
-// 取代旧的「仅挡 data:」策略：scheme allowlist 同时拦下 data:/javascript:/vbscript:/
-// file: 等一切非 http(s) scheme（契约 §1.4 + §3）。无 scheme 的相对地址也拒绝。
+// isAllowedImageURLScheme 判断 image url 是否为可用的 http(s) 绝对地址：
+// scheme 必须在 allowlist（仅 http/https）且 host 非空。取代旧的「仅挡 data:」
+// 策略：scheme allowlist 同时拦下 data:/javascript:/vbscript:/file: 等一切非
+// http(s) scheme（契约 §1.4 + §3）；host 检查再挡掉 http:// 无 host 的畸形地址
+// 与无 scheme 的相对地址。
 func isAllowedImageURLScheme(raw string) bool {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
@@ -244,7 +246,7 @@ func isAllowedImageURLScheme(raw string) bool {
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "http", "https":
-		return true
+		return u.Host != ""
 	default:
 		return false
 	}

--- a/common/richtext_test.go
+++ b/common/richtext_test.go
@@ -84,11 +84,11 @@ func TestFillPlain_ServerAuthoritative(t *testing.T) {
 }
 
 func TestValidateRichTextBlocks_ImageRules(t *testing.T) {
-	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: RichTextBlockImage}}); !errors.Is(err, ErrRichTextImageNoURL) {
+	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: RichTextBlockImage, Width: 1, Height: 1}}); !errors.Is(err, ErrRichTextImageNoURL) {
 		t.Errorf("missing url: got %v, want ErrRichTextImageNoURL", err)
 	}
-	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: RichTextBlockImage, URL: "data:image/png;base64,AAAA"}}); !errors.Is(err, ErrRichTextImageBase64) {
-		t.Errorf("base64 url: got %v, want ErrRichTextImageBase64", err)
+	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: RichTextBlockImage, URL: "data:image/png;base64,AAAA", Width: 1, Height: 1}}); !errors.Is(err, ErrRichTextImageBadScheme) {
+		t.Errorf("base64 url: got %v, want ErrRichTextImageBadScheme", err)
 	}
 	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: "video", Text: "x"}}); !errors.Is(err, ErrRichTextUnknownBlock) {
 		t.Errorf("unknown type: got %v, want ErrRichTextUnknownBlock", err)
@@ -98,6 +98,195 @@ func TestValidateRichTextBlocks_ImageRules(t *testing.T) {
 		{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 1, Height: 1},
 	}); err != nil {
 		t.Errorf("valid blocks rejected: %v", err)
+	}
+}
+
+// 契约 §1.3：text block 的 text 必填且非空（trim 后）。
+func TestValidateRichTextBlocks_TextRequired(t *testing.T) {
+	cases := []struct {
+		name  string
+		block RichTextBlock
+	}{
+		{"missing text", RichTextBlock{Type: RichTextBlockText}},
+		{"empty text", RichTextBlock{Type: RichTextBlockText, Text: ""}},
+		{"whitespace text", RichTextBlock{Type: RichTextBlockText, Text: "   \t\n"}},
+	}
+	for _, c := range cases {
+		if err := ValidateRichTextBlocks([]RichTextBlock{c.block}); !errors.Is(err, ErrRichTextTextEmpty) {
+			t.Errorf("%s: got %v, want ErrRichTextTextEmpty", c.name, err)
+		}
+	}
+	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: RichTextBlockText, Text: "hi"}}); err != nil {
+		t.Errorf("non-empty text rejected: %v", err)
+	}
+}
+
+// 契约 §1.4：image block 的 width/height 必填且 >0。
+func TestValidateRichTextBlocks_ImageDimensionsRequired(t *testing.T) {
+	cases := []struct {
+		name  string
+		block RichTextBlock
+	}{
+		{"no dimensions", RichTextBlock{Type: RichTextBlockImage, URL: "https://x/a.png"}},
+		{"zero width", RichTextBlock{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 0, Height: 10}},
+		{"zero height", RichTextBlock{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 10, Height: 0}},
+		{"negative width", RichTextBlock{Type: RichTextBlockImage, URL: "https://x/a.png", Width: -1, Height: 10}},
+		{"negative height", RichTextBlock{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 10, Height: -5}},
+	}
+	for _, c := range cases {
+		if err := ValidateRichTextBlocks([]RichTextBlock{c.block}); !errors.Is(err, ErrRichTextImageNoSize) {
+			t.Errorf("%s: got %v, want ErrRichTextImageNoSize", c.name, err)
+		}
+	}
+}
+
+// 契约 §1.4 + §3：image url 走 scheme allowlist（仅 http/https），拒一切其它 scheme。
+func TestValidateRichTextBlocks_ImageSchemeAllowlist(t *testing.T) {
+	bad := []string{
+		"data:image/png;base64,AAAA",
+		"DATA:image/png;base64,AAAA", // 大小写绕过
+		"  data:text/plain,hello  ",  // 前后空白 + 非 base64 data:
+		"javascript:alert(1)",
+		"vbscript:msgbox(1)",
+		"file:///etc/passwd",
+		"ftp://x/a.png",
+		"/relative/a.png", // 无 scheme
+		"x/a.png",         // 无 scheme
+	}
+	for _, u := range bad {
+		blk := RichTextBlock{Type: RichTextBlockImage, URL: u, Width: 1, Height: 1}
+		if err := ValidateRichTextBlocks([]RichTextBlock{blk}); !errors.Is(err, ErrRichTextImageBadScheme) {
+			t.Errorf("scheme %q: got %v, want ErrRichTextImageBadScheme", u, err)
+		}
+	}
+	good := []string{"http://x/a.png", "https://x/a.png", "HTTPS://X/A.PNG"}
+	for _, u := range good {
+		blk := RichTextBlock{Type: RichTextBlockImage, URL: u, Width: 1, Height: 1}
+		if err := ValidateRichTextBlocks([]RichTextBlock{blk}); err != nil {
+			t.Errorf("scheme %q rejected: %v", u, err)
+		}
+	}
+}
+
+// 契约 §1.1：顶层 content 必填且非空，拒 缺失 / null / 空数组。
+func TestValidateRichTextPayload_ContentRequired(t *testing.T) {
+	for _, raw := range []string{`{}`, `{"content":null}`, `{"content":[]}`, `{"plain":"x"}`} {
+		if _, err := ValidateRichTextPayload([]byte(raw)); !errors.Is(err, ErrRichTextEmptyContent) {
+			t.Errorf("%s: got %v, want ErrRichTextEmptyContent", raw, err)
+		}
+	}
+}
+
+// ValidateRichTextPayload 必须把 ValidateRichTextBlocks 的失败透传（守护 wiring）。
+func TestValidateRichTextPayload_RejectsInvalidBlock(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want error
+	}{
+		{"image no url", `{"content":[{"type":"image","width":1,"height":1}]}`, ErrRichTextImageNoURL},
+		{"image no size", `{"content":[{"type":"image","url":"https://x/a.png"}]}`, ErrRichTextImageNoSize},
+		{"image data uri", `{"content":[{"type":"image","url":"data:x","width":1,"height":1}]}`, ErrRichTextImageBadScheme},
+		{"text empty", `{"content":[{"type":"text","text":""}]}`, ErrRichTextTextEmpty},
+		{"unknown type", `{"content":[{"type":"video","text":"x"}]}`, ErrRichTextUnknownBlock},
+	}
+	for _, c := range cases {
+		if _, err := ValidateRichTextPayload([]byte(c.raw)); !errors.Is(err, c.want) {
+			t.Errorf("%s: got %v, want %v", c.name, err, c.want)
+		}
+	}
+}
+
+// 大小上限以下的坏 JSON 应返回解析错误（非 nil），不 panic。
+func TestValidateRichTextPayload_MalformedJSON(t *testing.T) {
+	if _, err := ValidateRichTextPayload([]byte(`{"content":`)); err == nil {
+		t.Errorf("malformed JSON under size limit: want parse error, got nil")
+	}
+}
+
+// FillPlainBounded：入站过校验的 payload，server 注入 plain 后若撑过 1MB 必须被拒。
+func TestFillPlainBounded_RejectsOversizeAfterPlain(t *testing.T) {
+	// 动态选 n：让入站序列化（plain 为空）恰好 ≤1MB，而 FillPlain 注入大量
+	// [图片] 占位符（每块 +8 字节）后撑过 1MB。逐步逼近 cap，避免硬编码块数随
+	// 结构微调而失配。
+	mk := func(n int) RichTextPayload {
+		content := make([]RichTextBlock, n)
+		for i := range content {
+			content[i] = RichTextBlock{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 1, Height: 1}
+		}
+		return RichTextPayload{Content: content}
+	}
+	n := 0
+	for {
+		next := n + 200
+		inbound, err := json.Marshal(mk(next))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(inbound) > RichTextMaxPayloadBytes {
+			break // n 保持为最后一个 ≤cap 的块数
+		}
+		n = next
+	}
+	if n < 1 {
+		t.Fatalf("could not size payload under cap")
+	}
+	p := mk(n)
+	inbound, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inbound) > RichTextMaxPayloadBytes {
+		t.Fatalf("inbound %d over cap, sizing failed", len(inbound))
+	}
+	// 入站校验放行。
+	if _, err := ValidateRichTextPayload(inbound); err != nil {
+		t.Fatalf("inbound payload (%d bytes) unexpectedly rejected: %v", len(inbound), err)
+	}
+	// server 注入 plain 后复检：应超限。
+	if _, err := p.FillPlainBounded(); !errors.Is(err, ErrRichTextPayloadTooLarge) {
+		t.Errorf("FillPlainBounded oversize: got %v, want ErrRichTextPayloadTooLarge", err)
+	}
+}
+
+// FillPlainBounded：正常体积 payload 应通过并回填 plain。
+func TestFillPlainBounded_OKForNormalPayload(t *testing.T) {
+	p := RichTextPayload{Content: []RichTextBlock{
+		{Type: RichTextBlockText, Text: "看图"},
+		{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 10, Height: 10},
+	}}
+	plain, err := p.FillPlainBounded()
+	if err != nil {
+		t.Fatalf("FillPlainBounded normal payload: %v", err)
+	}
+	if want := "看图" + RichTextImagePlaceholder; plain != want || p.Plain != want {
+		t.Errorf("plain = %q (field %q), want %q", plain, p.Plain, want)
+	}
+}
+
+// Marshal → Unmarshal 多 block round-trip（自定义 UnmarshalJSON 配默认 Marshal）。
+func TestRichText_MarshalUnmarshalRoundTrip(t *testing.T) {
+	orig := RichTextPayload{
+		Content: []RichTextBlock{
+			{Type: RichTextBlockText, Text: "看图"},
+			{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 100, Height: 80, Size: 1024, Name: "a.png"},
+			{Type: RichTextBlockText, Text: "结束"},
+		},
+		Plain: "看图[图片]结束",
+	}
+	b, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back RichTextPayload
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if len(back.Content) != 3 || back.Plain != orig.Plain {
+		t.Fatalf("round-trip mismatch: %+v", back)
+	}
+	if back.Content[1].URL != "https://x/a.png" || back.Content[1].Width != 100 || back.Content[1].Name != "a.png" {
+		t.Errorf("image block round-trip lost fields: %+v", back.Content[1])
 	}
 }
 

--- a/common/richtext_test.go
+++ b/common/richtext_test.go
@@ -1,0 +1,155 @@
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRichText_NewBlocksUnmarshalPreservesOrder(t *testing.T) {
+	raw := `{"content":[{"type":"text","text":"看图"},{"type":"image","url":"https://x/a.png","width":100,"height":80},{"type":"text","text":"结束"}]}`
+	var p RichTextPayload
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(p.Content) != 3 {
+		t.Fatalf("want 3 blocks, got %d", len(p.Content))
+	}
+	if p.Content[0].Type != RichTextBlockText || p.Content[0].Text != "看图" {
+		t.Errorf("block0 wrong: %+v", p.Content[0])
+	}
+	if p.Content[1].Type != RichTextBlockImage || p.Content[1].URL != "https://x/a.png" || p.Content[1].Width != 100 || p.Content[1].Height != 80 {
+		t.Errorf("block1 wrong: %+v", p.Content[1])
+	}
+	if p.Content[2].Text != "结束" {
+		t.Errorf("block2 wrong: %+v", p.Content[2])
+	}
+}
+
+// 向后兼容：老版本 content 是字符串，不能崩。
+func TestRichText_LegacyStringContentBackCompat(t *testing.T) {
+	raw := `{"content":"hello world"}`
+	var p RichTextPayload
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("legacy unmarshal must not fail: %v", err)
+	}
+	if len(p.Content) != 1 || p.Content[0].Type != RichTextBlockText || p.Content[0].Text != "hello world" {
+		t.Fatalf("legacy content not wrapped into text block: %+v", p.Content)
+	}
+	if p.Plain != "hello world" {
+		t.Errorf("legacy plain backfill = %q, want %q", p.Plain, "hello world")
+	}
+}
+
+func TestRichText_EmptyAndNullContent(t *testing.T) {
+	for _, raw := range []string{`{}`, `{"content":null}`, `{"content":[]}`} {
+		var p RichTextPayload
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			t.Fatalf("unmarshal %s: %v", raw, err)
+		}
+		if len(p.Content) != 0 {
+			t.Errorf("%s: want 0 blocks, got %d", raw, len(p.Content))
+		}
+	}
+}
+
+func TestBuildRichTextPlain(t *testing.T) {
+	content := []RichTextBlock{
+		{Type: RichTextBlockText, Text: "前"},
+		{Type: RichTextBlockImage, URL: "https://x/a.png"},
+		{Type: RichTextBlockText, Text: "后"},
+	}
+	got := BuildRichTextPlain(content)
+	want := "前" + RichTextImagePlaceholder + "后"
+	if got != want {
+		t.Errorf("plain = %q, want %q", got, want)
+	}
+}
+
+func TestFillPlain_ServerAuthoritative(t *testing.T) {
+	// 端上送了伪造 plain，server FillPlain 必须用 content 重算覆盖。
+	p := RichTextPayload{
+		Content: []RichTextBlock{
+			{Type: RichTextBlockText, Text: "a"},
+			{Type: RichTextBlockImage, URL: "https://x/i.png"},
+		},
+		Plain: "client-forged",
+	}
+	got := p.FillPlain()
+	want := "a" + RichTextImagePlaceholder
+	if got != want || p.Plain != want {
+		t.Errorf("FillPlain = %q (field %q), want %q", got, p.Plain, want)
+	}
+}
+
+func TestValidateRichTextBlocks_ImageRules(t *testing.T) {
+	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: RichTextBlockImage}}); !errors.Is(err, ErrRichTextImageNoURL) {
+		t.Errorf("missing url: got %v, want ErrRichTextImageNoURL", err)
+	}
+	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: RichTextBlockImage, URL: "data:image/png;base64,AAAA"}}); !errors.Is(err, ErrRichTextImageBase64) {
+		t.Errorf("base64 url: got %v, want ErrRichTextImageBase64", err)
+	}
+	if err := ValidateRichTextBlocks([]RichTextBlock{{Type: "video", Text: "x"}}); !errors.Is(err, ErrRichTextUnknownBlock) {
+		t.Errorf("unknown type: got %v, want ErrRichTextUnknownBlock", err)
+	}
+	if err := ValidateRichTextBlocks([]RichTextBlock{
+		{Type: RichTextBlockText, Text: "ok"},
+		{Type: RichTextBlockImage, URL: "https://x/a.png", Width: 1, Height: 1},
+	}); err != nil {
+		t.Errorf("valid blocks rejected: %v", err)
+	}
+}
+
+func TestValidateRichTextPayload_SizeLimit(t *testing.T) {
+	big := make([]byte, RichTextMaxPayloadBytes+1)
+	for i := range big {
+		big[i] = 'x'
+	}
+	if _, err := ValidateRichTextPayload(big); !errors.Is(err, ErrRichTextPayloadTooLarge) {
+		t.Errorf("oversize: got %v, want ErrRichTextPayloadTooLarge", err)
+	}
+}
+
+func TestValidateRichTextPayload_LegacyStringDoesNotCrash(t *testing.T) {
+	p, err := ValidateRichTextPayload([]byte(`{"content":"legacy"}`))
+	if err != nil {
+		t.Fatalf("legacy payload validation failed: %v", err)
+	}
+	if p.Content[0].Text != "legacy" {
+		t.Errorf("legacy content lost: %+v", p.Content)
+	}
+}
+
+func TestGetRichTextDisplayText(t *testing.T) {
+	// plain 优先。
+	if got := GetRichTextDisplayText([]byte(`{"content":[{"type":"text","text":"x"}],"plain":"已生成"}`)); got != "已生成" {
+		t.Errorf("plain priority: got %q", got)
+	}
+	// plain 空时遍历 content。
+	if got := GetRichTextDisplayText([]byte(`{"content":[{"type":"text","text":"hi"},{"type":"image","url":"u"}]}`)); got != "hi"+RichTextImagePlaceholder {
+		t.Errorf("derive from content: got %q", got)
+	}
+	// 空/坏 payload 回退静态名称。
+	for _, raw := range []string{``, `not-json`, `{"content":[]}`} {
+		if got := GetRichTextDisplayText([]byte(raw)); got != GetDisplayText(RichText.Int()) {
+			t.Errorf("fallback for %q: got %q, want %q", raw, got, GetDisplayText(RichText.Int()))
+		}
+	}
+}
+
+// 锁定字段名：序列化必须输出 content / plain，禁止 entities。
+func TestRichText_JSONFieldNamesLocked(t *testing.T) {
+	p := RichTextPayload{Content: []RichTextBlock{{Type: RichTextBlockText, Text: "x"}}, Plain: "x"}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"content"`) || !strings.Contains(s, `"plain"`) {
+		t.Errorf("missing locked field names: %s", s)
+	}
+	if strings.Contains(s, `"entities"`) || strings.Contains(s, `"offset"`) || strings.Contains(s, `"length"`) {
+		t.Errorf("forbidden field names leaked: %s", s)
+	}
+}

--- a/common/richtext_test.go
+++ b/common/richtext_test.go
@@ -152,6 +152,8 @@ func TestValidateRichTextBlocks_ImageSchemeAllowlist(t *testing.T) {
 		"ftp://x/a.png",
 		"/relative/a.png", // 无 scheme
 		"x/a.png",         // 无 scheme
+		"http://",         // scheme 对但无 host
+		"https://",        // scheme 对但无 host
 	}
 	for _, u := range bad {
 		blk := RichTextBlock{Type: RichTextBlockImage, URL: u, Width: 1, Height: 1}

--- a/docs/richtext-blocks-contract.md
+++ b/docs/richtext-blocks-contract.md
@@ -1,0 +1,139 @@
+# 图文混排 RichText (ContentType=14) blocks 跨端契约
+
+> 状态：Phase 0（协议地基/闸门）。本文档定义 `RichText=14` 的 blocks payload
+> schema 与跨端语义约定，五端（iOS / Android / Web / server / bot adapter）后续
+> 均 import 本契约实现。本 Phase 只落协议与工具函数，不碰任何业务渲染/发送逻辑。
+>
+> 来源：两轮跨端审计（YUJ-2740 设计 + YUJ-2745 补漏）。GH-Issue: #56。
+
+## 0. 基线决策（已定，勿推翻）
+
+- **复用 `RichText` ContentType=14**（见 `common/msg.go`），**不新增 type**。
+  - `type=20` 已是截屏消息，不可占用。
+- 正文以 **`content` 有序数组**承载，**数组顺序 = 图文穿插顺序**。
+- 顶层 **`plain`** 为冗余纯文本字段，**由 server 生成**（非端职责），供
+  search / 推送 / 摘要 / 复制 / 下游 LLM 复用。
+- **命名锁定 `content` / `plain`**。**禁用 `entities` + `offset/length`**：库内已
+  有多套同名异义 `entities`（robot mention 的 `Entitiy{Offset,Length}`、其它端的
+  range 标注），混用必错，务必避开。
+
+## 1. Payload Schema
+
+RichText(=14) 消息的 `payload`（JSON 对象）：
+
+```jsonc
+{
+  "content": [                       // 有序数组，顺序即图文穿插顺序
+    { "type": "text",  "text": "看这张图：" },
+    { "type": "image", "url": "https://cdn/.../a.png", "width": 1080, "height": 720, "size": 81920, "name": "a.png" },
+    { "type": "text",  "text": "怎么样？" }
+  ],
+  "plain": "看这张图：[图片]怎么样？"   // server 生成的冗余纯文本
+}
+```
+
+### 1.1 顶层字段
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `content` | `array<block>` | 是 | 有序 block 数组，顺序即展示顺序 |
+| `plain` | `string` | 是（语义必填） | 纯文本冗余字段，**由 server 生成**，供 search/推送/摘要/复制/LLM 复用 |
+
+### 1.2 block 公共字段
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `type` | `string` | 是 | block 类型枚举：`"text"` / `"image"`（显式枚举，二期富文本格式在此扩展） |
+
+### 1.3 `type:"text"` 文本块
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `text` | `string` | 是 | 文本内容。**MVP 锁定：纯文本，不渲染 markdown** |
+
+### 1.4 `type:"image"` 图片块
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `url` | `string` | 是 | 图片引用地址。**只接受 url 引用，禁止内嵌 base64（`data:` URI）** |
+| `width` | `int` | 是 | 图片宽度（像素），供端上占位排版避免抖动 |
+| `height` | `int` | 是 | 图片高度（像素） |
+| `size` | `int` | 否 | 图片字节大小 |
+| `name` | `string` | 否 | 原始文件名 |
+
+> Go 类型对应：`common.RichTextPayload` / `common.RichTextBlock`，常量
+> `common.RichTextBlockText` / `common.RichTextBlockImage`。
+
+## 2. `plain` 生成规则（server 权威）
+
+`plain` **不是端的职责**，端上送的 `plain` 一律不可信。server 在入库出口调用
+`common.RichTextPayload.FillPlain()`（底层 `common.BuildRichTextPlain`）重算并覆盖：
+
+- 遍历 `content`，**按数组顺序**拼接；
+- `text` block → 取 `text`；
+- `image` block → 注入占位符 **`[图片]`**（`common.RichTextImagePlaceholder`）；
+- 结果写回 `plain`。
+
+示例：`[text "看图", image, text "结束"]` → `plain = "看图[图片]结束"`。
+
+## 3. 大小上限与禁内嵌
+
+- payload 序列化后 **硬上限 1MB**（`common.RichTextMaxPayloadBytes`）。
+- 图片块 **只接受 url 引用**；内嵌 base64（`data:` URI）被
+  `ValidateRichTextBlocks` 拒绝（`ErrRichTextImageBase64`）。这是 1MB 上限能成立
+  的前提。
+
+## 4. 向后兼容（老字符串 content 不能崩）
+
+历史上 `RichText` 的 `content` 曾是字符串。本 schema 的 `UnmarshalJSON` 兼容：
+
+- `{"content":"hello"}` → 解析为单个 `text` block（`text="hello"`），且 `plain`
+  为空时回填为该字符串；
+- `{"content":[...]}` → 正常解析为 block 数组。
+
+老路径解析、校验（`ValidateRichTextPayload`）、展示（`GetRichTextDisplayText`）
+均不崩。`GetRichTextDisplayText` 是对既有 `GetDisplayText` 的补充：优先用 `plain`，
+其次现场遍历 `content`，最后回退静态名称「富文本消息」。
+
+## 5. 跨端语义约定
+
+### 5.1 part-fail 回滚语义
+
+一条图文混排消息是**原子**的：
+
+- 若任一图片上传/任一 block 准备失败 → **整条 fail，不发送**；
+- **不清空草稿（draft）**，用户可重试或编辑后重发；
+- 不允许"发出去一半"（部分 block 成功部分失败）。
+
+### 5.2 截断按段（block）规则
+
+需要截断展示/摘要时，**按 block 边界截断，不在 block 内部切断**：
+
+- 累积到长度上限时，丢弃后续整块，不切碎单个 text/image block；
+- 摘要/列表预览用 `plain`（其中 image 已是 `[图片]` 占位），按字符上限截断即可。
+
+### 5.3 MVP 锁定项
+
+- `text` block = **纯文本**，**不渲染 markdown**（二期再开富文本格式，届时通过新增
+  block `type` 或字段扩展，老端按未知类型前向兼容降级）。
+
+## 6. 明确不做（留后续 Phase）
+
+本 Phase **只做协议 + 工具函数**。以下不在范围：三端渲染 provider、发送端编辑器、
+bot adapter 的 enum/case、octo-smart-summary / octo-matter / search 的 `type=14`
+分支。
+
+## 7. Go API 速查
+
+| 符号 | 用途 |
+|------|------|
+| `common.RichTextPayload{Content, Plain}` | payload 结构（含向后兼容 `UnmarshalJSON`） |
+| `common.RichTextBlock{Type, Text, URL, Width, Height, Size, Name}` | 单个 block |
+| `common.RichTextBlockText` / `common.RichTextBlockImage` | block type 常量 |
+| `common.RichTextImagePlaceholder` (`"[图片]"`) | image 占位符 |
+| `common.RichTextMaxPayloadBytes` (1MB) | payload 大小上限 |
+| `common.BuildRichTextPlain(content)` | 遍历 blocks 生成 plain |
+| `(*RichTextPayload).FillPlain()` | server 用 content 重算并回填 plain |
+| `common.ValidateRichTextBlocks(content)` | 校验 block 结构 |
+| `common.ValidateRichTextPayload(data)` | 校验大小+结构，返回解析结果 |
+| `common.GetRichTextDisplayText(payload)` | 取展示文本（plain 优先，向后兼容） |

--- a/docs/richtext-blocks-contract.md
+++ b/docs/richtext-blocks-contract.md
@@ -36,7 +36,7 @@ RichText(=14) 消息的 `payload`（JSON 对象）：
 
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `content` | `array<block>` | 是 | 有序 block 数组，顺序即展示顺序 |
+| `content` | `array<block>` | 是 | 有序 block 数组，顺序即展示顺序。**必填且非空**：`ValidateRichTextPayload` 拒绝 `content` 缺失 / `null` / 空数组 `[]`（`ErrRichTextEmptyContent`） |
 | `plain` | `string` | 是（语义必填） | 纯文本冗余字段，**由 server 生成**，供 search/推送/摘要/复制/LLM 复用 |
 
 ### 1.2 block 公共字段
@@ -49,15 +49,15 @@ RichText(=14) 消息的 `payload`（JSON 对象）：
 
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `text` | `string` | 是 | 文本内容。**MVP 锁定：纯文本，不渲染 markdown** |
+| `text` | `string` | 是 | 文本内容（trim 后非空）。**MVP 锁定：纯文本，不渲染 markdown**。`ValidateRichTextBlocks` 拒绝缺失/纯空白 `text`（`ErrRichTextTextEmpty`） |
 
 ### 1.4 `type:"image"` 图片块
 
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `url` | `string` | 是 | 图片引用地址。**只接受 url 引用，禁止内嵌 base64（`data:` URI）** |
-| `width` | `int` | 是 | 图片宽度（像素），供端上占位排版避免抖动 |
-| `height` | `int` | 是 | 图片高度（像素） |
+| `url` | `string` | 是 | 图片引用地址。**scheme allowlist：仅 `http`/`https`**；拒 `data:`/`javascript:`/`file:` 等一切其它 scheme（`ErrRichTextImageBadScheme`），亦即禁止内嵌 base64 |
+| `width` | `int` | 是（`>0`） | 图片宽度（像素），供端上占位排版避免抖动；缺失/≤0 被拒（`ErrRichTextImageNoSize`） |
+| `height` | `int` | 是（`>0`） | 图片高度（像素）；缺失/≤0 被拒（`ErrRichTextImageNoSize`） |
 | `size` | `int` | 否 | 图片字节大小 |
 | `name` | `string` | 否 | 原始文件名 |
 
@@ -67,21 +67,38 @@ RichText(=14) 消息的 `payload`（JSON 对象）：
 ## 2. `plain` 生成规则（server 权威）
 
 `plain` **不是端的职责**，端上送的 `plain` 一律不可信。server 在入库出口调用
-`common.RichTextPayload.FillPlain()`（底层 `common.BuildRichTextPlain`）重算并覆盖：
+`common.RichTextPayload.FillPlainBounded()`（底层 `FillPlain` → `common.BuildRichTextPlain`）
+重算并覆盖：
 
 - 遍历 `content`，**按数组顺序**拼接；
 - `text` block → 取 `text`；
 - `image` block → 注入占位符 **`[图片]`**（`common.RichTextImagePlaceholder`）；
-- 结果写回 `plain`。
+- 结果写回 `plain`，并对回填后的整条 payload 复检 1MB 上限（见 §3）。
 
 示例：`[text "看图", image, text "结束"]` → `plain = "看图[图片]结束"`。
+
+### 2.1 信任边界（入站校验路径 vs 存储后展示路径）
+
+端上送的 `plain` 不可信，必须区分两条路径：
+
+- **入站校验路径**：收到端上 payload → `ValidateRichTextPayload`（校验 content/字段）
+  → `FillPlainBounded`（用 `content` 重建 `plain` 并复检大小）。**此路径严禁直接信任
+  或展示端上送的原始 `plain`**——它可被伪造。
+- **存储后展示路径**：payload 已入库、`plain` 已由 server 经 `FillPlainBounded` 权威
+  生成。此时 `common.GetRichTextDisplayText` 信任 `plain` 是正确且高效的展示入口
+  （函数注释已写明此前提）。
 
 ## 3. 大小上限与禁内嵌
 
 - payload 序列化后 **硬上限 1MB**（`common.RichTextMaxPayloadBytes`）。
-- 图片块 **只接受 url 引用**；内嵌 base64（`data:` URI）被
-  `ValidateRichTextBlocks` 拒绝（`ErrRichTextImageBase64`）。这是 1MB 上限能成立
-  的前提。
+- 入站校验 `ValidateRichTextPayload` 只校验**原始入站字节**大小；server 注入
+  `plain` 后须用 `FillPlainBounded` **复检回填后的整体大小**——`[图片]` 占位符注入
+  可能把入站时刚好压线的 payload 撑过 1MB，故出站前必须再检一次（超限返回
+  `ErrRichTextPayloadTooLarge`）。
+- 图片块 `url` 走 **scheme allowlist：仅 `http`/`https`**；`data:`/`javascript:`/
+  `file:` 等一切其它 scheme 被 `ValidateRichTextBlocks` 拒绝
+  （`ErrRichTextImageBadScheme`）。禁内嵌 base64（`data:` URI）是其子集，也是 1MB
+  上限能成立的前提。
 
 ## 4. 向后兼容（老字符串 content 不能崩）
 
@@ -92,8 +109,9 @@ RichText(=14) 消息的 `payload`（JSON 对象）：
 - `{"content":[...]}` → 正常解析为 block 数组。
 
 老路径解析、校验（`ValidateRichTextPayload`）、展示（`GetRichTextDisplayText`）
-均不崩。`GetRichTextDisplayText` 是对既有 `GetDisplayText` 的补充：优先用 `plain`，
-其次现场遍历 `content`，最后回退静态名称「富文本消息」。
+均不崩。`GetRichTextDisplayText` 是对既有 `GetDisplayText` 的补充：优先用 `plain`
+（仅在已 `FillPlainBounded` 的存储后展示路径可信，见 §2.1），其次现场遍历 `content`，
+最后回退静态名称「富文本消息」。
 
 ## 5. 跨端语义约定
 
@@ -117,6 +135,22 @@ RichText(=14) 消息的 `payload`（JSON 对象）：
 - `text` block = **纯文本**，**不渲染 markdown**（二期再开富文本格式，届时通过新增
   block `type` 或字段扩展，老端按未知类型前向兼容降级）。
 
+### 5.4 未知 block type 的 Postel 策略（write-strict / read-lenient）
+
+本契约对未知 block `type` 采用 **Postel 原则**——发送时严格，解析时宽容：
+
+- **write-strict（写入/发送端）**：`ValidateRichTextBlocks` / `ValidateRichTextPayload`
+  对未知 `type` **硬拒**（`ErrRichTextUnknownBlock`）。MVP 发送端只准 `text` / `image`，
+  不允许写出未登记的 block type。
+- **read-lenient（解析/展示端）**：`BuildRichTextPlain` / `GetRichTextDisplayText`
+  遇未知 block **不崩**——有 `text` 字段则降级取其文本，否则跳过该块，继续渲染其余
+  block。这保证二期新增 block type 后，老端解析新消息不会整条失败。
+
+由此，二期扩展新 block type 时：升级发送端的 write 校验放行新 type，老解析端无需改动
+即可前向兼容降级。**注意**：因校验先于展示，老 server 的入站 gate 会先于宽容展示路径
+拒掉新 type 的**写入**——这是有意为之（gate 防止未登记内容入库），新 type 的落地需要
+先升级 server 端校验白名单。
+
 ## 6. 明确不做（留后续 Phase）
 
 本 Phase **只做协议 + 工具函数**。以下不在范围：三端渲染 provider、发送端编辑器、
@@ -132,8 +166,9 @@ bot adapter 的 enum/case、octo-smart-summary / octo-matter / search 的 `type=
 | `common.RichTextBlockText` / `common.RichTextBlockImage` | block type 常量 |
 | `common.RichTextImagePlaceholder` (`"[图片]"`) | image 占位符 |
 | `common.RichTextMaxPayloadBytes` (1MB) | payload 大小上限 |
-| `common.BuildRichTextPlain(content)` | 遍历 blocks 生成 plain |
-| `(*RichTextPayload).FillPlain()` | server 用 content 重算并回填 plain |
-| `common.ValidateRichTextBlocks(content)` | 校验 block 结构 |
-| `common.ValidateRichTextPayload(data)` | 校验大小+结构，返回解析结果 |
-| `common.GetRichTextDisplayText(payload)` | 取展示文本（plain 优先，向后兼容） |
+| `common.BuildRichTextPlain(content)` | 遍历 blocks 生成 plain（read-lenient：未知 type 降级） |
+| `(*RichTextPayload).FillPlain()` | server 用 content 重算并回填 plain（不复检大小） |
+| `(*RichTextPayload).FillPlainBounded()` | 入库出口权威路径：FillPlain + 回填后 1MB 复检 |
+| `common.ValidateRichTextBlocks(content)` | 校验 block 结构（write-strict：必填字段 + scheme allowlist） |
+| `common.ValidateRichTextPayload(data)` | 校验大小+content 非空+结构，返回解析结果 |
+| `common.GetRichTextDisplayText(payload)` | 取展示文本（plain 优先，仅存储后路径可信，见 §2.1） |


### PR DESCRIPTION
## 图文混排 RichText=14 blocks schema + 跨端契约 (Phase 0)

Fixes #56

协议地基/闸门：在 octo-lib 定义 `RichText` ContentType=14 的图文混排 blocks payload schema + 跨端契约文档，五端后续 import。**只做协议 + 工具函数，不碰任何业务渲染/发送逻辑。**

### 基线（两轮跨端审计 YUJ-2740/2745 已定）
复用已存在的 `RichText=14`（`common/msg.go:41`），不新增 type；`content` 有序数组承载图文，顺序=穿插顺序；顶层 `plain` 冗余文本由 server 生成。命名锁定 `content`/`plain`，**禁用 `entities` + `offset/length`**（库内已有同名异义 entities，混用必错）。

### 改动
**`common/richtext.go`**（+214）
- `RichTextPayload{Content, Plain}` / `RichTextBlock{Type, Text, URL, Width, Height, Size, Name}`
- block type 显式常量 `RichTextBlockText`/`RichTextBlockImage`（二期扩展预留）
- `BuildRichTextPlain` + `(*RichTextPayload).FillPlain()` — server 入库出口遍历 content 生成 plain，image 注入 `[图片]` 占位（契约上 plain 由 server 生成，端上送的不可信）
- `ValidateRichTextBlocks` / `ValidateRichTextPayload` — 1MB 硬上限、image 必带 url、禁内嵌 base64（`data:` URI）
- `GetRichTextDisplayText` — 补充既有 `GetDisplayText`，拿到 payload 时走 plain
- **向后兼容**：`UnmarshalJSON` 兼容老版本字符串 `content`（包成单个 text block + 回填 plain），老路径不崩

**`docs/richtext-blocks-contract.md`**（+139）
- schema 字段表 + plain 生成规则 + part-fail 回滚语义（整条 fail 不发、不清 draft）+ 截断按 block 边界规则 + MVP 锁定 text=纯文本（不渲染 markdown）+ 1MB/禁 base64 + Go API 速查

**`common/richtext_test.go`**（+155）— 9 个用例覆盖新结构解析/老字符串兼容/plain 生成/server 权威覆盖/校验规则/字段名锁定。

### 明确不做（留后续 Phase）
三端渲染 provider、发送端编辑器、bot adapter enum/case、octo-smart-summary/octo-matter/search 的 type=14 分支。

### 验证
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅（全仓通过）
- gofmt clean ✅ · 无导出名冲突 ✅

### 审查状态
- 改动规模：+508 行, 3 文件（其中 1 测试 + 1 文档）
- /review (自审): PASS ✅ — 纯协议层新增，无 SQL / 无 LLM 信任边界 / 无条件副作用；唯一信任边界是端上送 `plain` 被 `FillPlain` server 端重算覆盖，已编码并测试；向后兼容老字符串 content 路径已测
- 本单走完后另派 ReviewBot 独立 codex-review
