### PR TITLE
ci: pin all GitHub Actions to exact SHA digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Build
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Test
@@ -103,8 +103,8 @@ jobs:
     name: Vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Vet


### PR DESCRIPTION
## What

Replace all remaining tag-based action references (`@v4`/`@v5`) with SHA-pinned versions plus version comments in the build, test, and vet jobs.

## Why

Tag refs can be force-pushed, creating a supply chain attack vector. SHA pinning ensures the exact code version is used. The `changes` job was already pinned; this PR completes the remaining 6 references.

## Changes

- 3× `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
- 3× `actions/setup-go@v5` → `actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5`

## Verification

```
grep -r '@v[0-9]' .github/workflows/
```
Returns empty — all actions are now SHA-pinned.