### PR TITLE
feat(config): 头像对象键支持版本感知路径 (closes #62)

### DIFF
--- a/config/avatar_path_test.go
+++ b/config/avatar_path_test.go
@@ -111,3 +111,30 @@ func TestAvatarVersionedPathDiffersFromLegacy(t *testing.T) {
 		})
 	}
 }
+
+// TestAvatarDistinctVersionsProduceDistinctPaths 锁定「每个版本号产生唯一对象键」契约,
+// 这是缓存失效生效的前提:版本变化时对象键必须变化。
+func TestAvatarDistinctVersionsProduceDistinctPaths(t *testing.T) {
+	cfg := newAvatarTestConfig()
+
+	if v1, v2 := cfg.GetGroupAvatarFilePath("G123", 1), cfg.GetGroupAvatarFilePath("G123", 2); v1 == v2 {
+		t.Errorf("distinct versions should produce distinct paths, both = %q", v1)
+	}
+	if v1, v2 := cfg.GetCommunityAvatarFilePath("C456", 1), cfg.GetCommunityAvatarFilePath("C456", 2); v1 == v2 {
+		t.Errorf("distinct versions should produce distinct paths, both = %q", v1)
+	}
+	if v1, v2 := cfg.GetCommunityCoverFilePath("C789", 1), cfg.GetCommunityCoverFilePath("C789", 2); v1 == v2 {
+		t.Errorf("distinct versions should produce distinct paths, both = %q", v1)
+	}
+}
+
+// TestAvatarVersionFirstWins 验证变参的「仅取第一个参数」语义:多传的版本号被忽略。
+func TestAvatarVersionFirstWins(t *testing.T) {
+	cfg := newAvatarTestConfig()
+
+	got := cfg.GetGroupAvatarFilePath("G123", 7, 99, 100)
+	want := "group/60/G123/7.png"
+	if got != want {
+		t.Errorf("GetGroupAvatarFilePath first-wins: got %q, want %q", got, want)
+	}
+}

--- a/config/avatar_path_test.go
+++ b/config/avatar_path_test.go
@@ -1,0 +1,113 @@
+package config
+
+import "testing"
+
+// newAvatarTestConfig 返回一个固定 Avatar.Partition 的配置,使路径分区可被确定性断言。
+func newAvatarTestConfig() *Config {
+	cfg := New()
+	cfg.Avatar.Partition = 100
+	return cfg
+}
+
+// crc32 % 100 的确定性结果(Partition=100):
+//
+//	"G123" -> 60, "C456" -> 84, "C789" -> 89
+func TestGetGroupAvatarFilePath(t *testing.T) {
+	cfg := newAvatarTestConfig()
+
+	tests := []struct {
+		name    string
+		groupNo string
+		version []int64
+		want    string
+	}{
+		{"no version returns legacy path", "G123", nil, "group/60/G123.png"},
+		{"zero version returns legacy path", "G123", []int64{0}, "group/60/G123.png"},
+		{"negative version returns legacy path", "G123", []int64{-1}, "group/60/G123.png"},
+		{"positive version returns versioned path", "G123", []int64{7}, "group/60/G123/7.png"},
+		{"large positive version", "G123", []int64{1717171717}, "group/60/G123/1717171717.png"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetGroupAvatarFilePath(tt.groupNo, tt.version...)
+			if got != tt.want {
+				t.Errorf("GetGroupAvatarFilePath(%q, %v) = %q, want %q", tt.groupNo, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCommunityAvatarFilePath(t *testing.T) {
+	cfg := newAvatarTestConfig()
+
+	tests := []struct {
+		name        string
+		communityNo string
+		version     []int64
+		want        string
+	}{
+		{"no version returns legacy path", "C456", nil, "community/84/C456.png"},
+		{"zero version returns legacy path", "C456", []int64{0}, "community/84/C456.png"},
+		{"negative version returns legacy path", "C456", []int64{-5}, "community/84/C456.png"},
+		{"positive version returns versioned path", "C456", []int64{42}, "community/84/C456/42.png"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetCommunityAvatarFilePath(tt.communityNo, tt.version...)
+			if got != tt.want {
+				t.Errorf("GetCommunityAvatarFilePath(%q, %v) = %q, want %q", tt.communityNo, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCommunityCoverFilePath(t *testing.T) {
+	cfg := newAvatarTestConfig()
+
+	tests := []struct {
+		name        string
+		communityNo string
+		version     []int64
+		want        string
+	}{
+		{"no version returns legacy path", "C789", nil, "community/89/C789_cover.png"},
+		{"zero version returns legacy path", "C789", []int64{0}, "community/89/C789_cover.png"},
+		{"negative version returns legacy path", "C789", []int64{-1}, "community/89/C789_cover.png"},
+		{"positive version returns versioned path", "C789", []int64{9}, "community/89/C789/cover/9.png"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.GetCommunityCoverFilePath(tt.communityNo, tt.version...)
+			if got != tt.want {
+				t.Errorf("GetCommunityCoverFilePath(%q, %v) = %q, want %q", tt.communityNo, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAvatarVersionedPathDiffersFromLegacy 确认带版本路径与旧版路径不同(对象键确实变化),
+// 这是规避忽略 query string 的 CDN 缓存的关键属性。
+func TestAvatarVersionedPathDiffersFromLegacy(t *testing.T) {
+	cfg := newAvatarTestConfig()
+
+	cases := []struct {
+		name      string
+		legacy    string
+		versioned string
+	}{
+		{"group", cfg.GetGroupAvatarFilePath("G123"), cfg.GetGroupAvatarFilePath("G123", 1)},
+		{"community", cfg.GetCommunityAvatarFilePath("C456"), cfg.GetCommunityAvatarFilePath("C456", 1)},
+		{"cover", cfg.GetCommunityCoverFilePath("C789"), cfg.GetCommunityCoverFilePath("C789", 1)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.legacy == tc.versioned {
+				t.Errorf("versioned path should differ from legacy, both = %q", tc.legacy)
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -876,21 +876,44 @@ func (c *Config) GetAvatarPath(uid string) string {
 	return fmt.Sprintf("users/%s/avatar", uid)
 }
 
-// GetGroupAvatarFilePath 获取群头像上传路径
-func (c *Config) GetGroupAvatarFilePath(groupNo string) string {
+// avatarVersion 从变参中取头像版本号。
+// 缺省或非正值表示使用旧版(无版本)路径,从而保持向后兼容。
+func avatarVersion(version []int64) int64 {
+	if len(version) > 0 {
+		return version[0]
+	}
+	return 0
+}
+
+// GetGroupAvatarFilePath 获取群头像上传路径。
+// 不传 version 或 version <= 0 时返回旧版稳定路径;version > 0 时返回带版本的路径,
+// 使对象键随每次上传变化,以规避忽略 query string 的 CDN 缓存。
+func (c *Config) GetGroupAvatarFilePath(groupNo string, version ...int64) string {
 	avatarID := crc32.ChecksumIEEE([]byte(groupNo)) % uint32(c.Avatar.Partition)
+	if v := avatarVersion(version); v > 0 {
+		return fmt.Sprintf("group/%d/%s/%d.png", avatarID, groupNo, v)
+	}
 	return fmt.Sprintf("group/%d/%s.png", avatarID, groupNo)
 }
 
-// GetCommunityAvatarFilePath 获取社区头像上传路径
-func (c *Config) GetCommunityAvatarFilePath(communityNo string) string {
+// GetCommunityAvatarFilePath 获取社区头像上传路径。
+// 不传 version 或 version <= 0 时返回旧版稳定路径;version > 0 时返回带版本的路径。
+func (c *Config) GetCommunityAvatarFilePath(communityNo string, version ...int64) string {
 	avatarID := crc32.ChecksumIEEE([]byte(communityNo)) % uint32(c.Avatar.Partition)
+	if v := avatarVersion(version); v > 0 {
+		return fmt.Sprintf("community/%d/%s/%d.png", avatarID, communityNo, v)
+	}
 	return fmt.Sprintf("community/%d/%s.png", avatarID, communityNo)
 }
 
-// GetCommunityCoverFilePath 获取社区封面上传路径
-func (c *Config) GetCommunityCoverFilePath(communityNo string) string {
+// GetCommunityCoverFilePath 获取社区封面上传路径。
+// 不传 version 或 version <= 0 时返回旧版稳定路径;version > 0 时返回带版本的路径,
+// 版本路径形态避免与旧版 community/<partition>/<community_no>_cover.png 冲突。
+func (c *Config) GetCommunityCoverFilePath(communityNo string, version ...int64) string {
 	avatarID := crc32.ChecksumIEEE([]byte(communityNo)) % uint32(c.Avatar.Partition)
+	if v := avatarVersion(version); v > 0 {
+		return fmt.Sprintf("community/%d/%s/cover/%d.png", avatarID, communityNo, v)
+	}
 	return fmt.Sprintf("community/%d/%s_cover.png", avatarID, communityNo)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -877,7 +877,8 @@ func (c *Config) GetAvatarPath(uid string) string {
 }
 
 // avatarVersion 从变参中取头像版本号。
-// 缺省或非正值表示使用旧版(无版本)路径,从而保持向后兼容。
+// 仅取第一个参数(first-wins),其余忽略;缺省或非正值表示使用旧版(无版本)路径,
+// 从而保持向后兼容。
 func avatarVersion(version []int64) int64 {
 	if len(version) > 0 {
 		return version[0]


### PR DESCRIPTION
## 背景

`octo-server` 存在头像缓存失效问题(关联 Mininglamp-OSS/octo-server#281):当 CDN 缓存键不含 query string 时,靠 `?v=` 追加到 redirect URL 无法生效——覆盖写同一对象键后,CDN 会持续返回旧对象。

`octo-lib` 拥有共享的头像/封面对象键 helper,本 PR 让它们**版本感知**,使对象键随每次上传变化,从根上规避该问题。

## 改动

将三个 helper 改为变参 `version ...int64`(源码级向后兼容):

| 调用 | 返回 |
|------|------|
| `GetGroupAvatarFilePath(no)` / `version <= 0` | `group/<p>/<no>.png`(旧版,逐字不变)|
| `GetGroupAvatarFilePath(no, v)` `v>0` | `group/<p>/<no>/<v>.png` |
| `GetCommunityAvatarFilePath(no, v)` `v>0` | `community/<p>/<no>/<v>.png` |
| `GetCommunityCoverFilePath(no, v)` `v>0` | `community/<p>/<no>/cover/<v>.png` |

- 封面版本路径 `.../cover/<v>.png` 避免与旧版 `<no>_cover.png` 冲突。
- 新增私有 `avatarVersion([]int64) int64` 统一变参取值语义。

## 验收对照(Issue #62)

- ✅ 无版本调用返回与今天完全相同的字符串
- ✅ `version <= 0` 返回与今天相同的字符串
- ✅ `version > 0` 把版本放进对象路径而非 query string
- ✅ 三个 helper 各加表驱动单测
- ✅ 未触碰 `GetAvatarPath` 等客户端路由 helper
- ✅ 不引入 CDN 失效逻辑 / AWS / CloudFront 依赖
- ✅ 变参保证现有调用方零改动

## 测试

```
go vet ./config/
go test -race -cover ./config/   # PASS
```

新增 `config/avatar_path_test.go`,覆盖每个 helper 的旧版/零值/负值/正值场景,并断言版本路径确实区别于旧版路径。