### PR TITLE
ci(codeql): restore CodeQL as weekly scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,12 @@
 name: CodeQL
 
 on:
-  # Weekly deep scan only — CodeQL is the slow, cross-function SAST tier.
-  # NOTE: no per-PR SAST remains; per-PR CI runs the repo's own lint +
-  # osv-scanner (dependency CVEs). CodeQL is a weekly deep scan + manual
-  # dispatch; findings land in the Security tab. Detection latency for new
-  # code-level vulnerabilities widens to up to ~7 days.
+  # Weekly deep scan only. CodeQL (cross-function SAST) is intentionally NOT run
+  # per-PR or per-push: this removes pre-merge and per-merge SAST entirely. The
+  # only remaining code-level SAST is this weekly scan + manual dispatch. Per-PR
+  # CI still runs osv-scanner (dependency CVEs) — that is SCA, not SAST. Detection
+  # latency for newly introduced code-level vulnerabilities is up to ~7 days;
+  # findings land in the Security tab.
   schedule:
     - cron: "0 6 * * 1"   # Mondays 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: CodeQL
+
+on:
+  # Weekly deep scan only — CodeQL is the slow, cross-function SAST tier.
+  # NOTE: no per-PR SAST remains; per-PR CI runs the repo's own lint +
+  # osv-scanner (dependency CVEs). CodeQL is a weekly deep scan + manual
+  # dispatch; findings land in the Security tab. Detection latency for new
+  # code-level vulnerabilities widens to up to ~7 days.
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@v1
+    with:
+      language: go
+    permissions:
+      actions: read
+      contents: read
+      security-events: write


### PR DESCRIPTION
PR #68 removed CodeQL under a 'low input-surface' premise. Restoring it as a **weekly schedule + manual dispatch** (consistent with the rest of the org) to preserve Go SAST coverage. Per-PR cost is zero (weekly cadence); osv-scanner still covers dependency CVEs per-PR. Findings land in the Security tab.