### PR TITLE
feat(envelope): canonical response envelope types + wkhttp helpers (R1/R5)

### DIFF
--- a/pkg/envelope/envelope.go
+++ b/pkg/envelope/envelope.go
@@ -1,0 +1,83 @@
+// Package envelope defines the canonical OCTO API response wire shapes.
+//
+// Per the OCTO API spec (octo-openapi-dev-skill, rules R1/R2/R5), every
+// endpoint response is wrapped in one of five envelopes:
+//
+//	Data[T]       { "data": T }
+//	CursorList[T] { "data": [T], "pagination": {has_more, next_cursor} }
+//	OffsetList[T] { "data": [T], "pagination": {total, page, page_size} }
+//	Data[EmptyResp] { "data": {} }            — delete / state-machine success
+//	Error         { "error": {code, message, details, hint} }
+//
+// The package is dependency-free on purpose: services that do not use
+// pkg/wkhttp (plain gin or otherwise) can still reference these types in
+// swag annotations and response construction. pkg/wkhttp provides
+// Context helpers (ResponseData / ResponseCursor / ...) that emit these
+// exact shapes.
+//
+// The contract is the WIRE SHAPE, not the type names — linting validates
+// the generated OpenAPI structure (top-level `data` / `error`), so any
+// implementation producing the same JSON is compliant. These types are
+// the recommended shared implementation.
+package envelope
+
+// Data is the single-object success envelope (R1): { "data": T }.
+// Use it for get / create / update responses, and Data[EmptyResp] for
+// success responses that carry no payload.
+type Data[T any] struct {
+	Data T `json:"data"`
+}
+
+// EmptyResp marshals to {}. Data[EmptyResp] renders { "data": {} } — the
+// canonical success shape for delete and state-machine actions (R1).
+type EmptyResp struct{}
+
+// CursorPagination is the cursor-mode pagination block (R5).
+// NextCursor is an opaque server token; it is omitted when there is no
+// further page. Cursor mode must NOT include a total count.
+type CursorPagination struct {
+	HasMore    bool   `json:"has_more"`
+	NextCursor string `json:"next_cursor,omitempty"`
+}
+
+// OffsetPagination is the offset-mode pagination block (R5).
+type OffsetPagination struct {
+	Total    int64 `json:"total"`
+	Page     int   `json:"page"`
+	PageSize int   `json:"page_size"`
+}
+
+// CursorList is the cursor-paginated list envelope (R1 + R5):
+// { "data": [T], "pagination": {has_more, next_cursor} }.
+type CursorList[T any] struct {
+	Data       []T              `json:"data"`
+	Pagination CursorPagination `json:"pagination"`
+}
+
+// OffsetList is the offset-paginated list envelope (R1 + R5):
+// { "data": [T], "pagination": {total, page, page_size} }.
+type OffsetList[T any] struct {
+	Data       []T              `json:"data"`
+	Pagination OffsetPagination `json:"pagination"`
+}
+
+// Error is the failure envelope for all 4xx/5xx responses (R1 + R2):
+// { "error": {code, message, details, hint} }.
+//
+// This is the spec shape; a service may render a superset for legacy
+// compatibility (e.g. octo-server's D14 renderer adds msg/status
+// siblings) — the contract only requires the top-level `error` object.
+type Error struct {
+	Error ErrorBody `json:"error"`
+}
+
+// ErrorBody carries the R2 error fields. Code is one of the 12 fixed
+// enum values (or a service-defined registry id during migration);
+// Details is structured, machine-readable sub-classification; Hint is an
+// optional human-readable recovery suggestion.
+type ErrorBody struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
+	Hint    string         `json:"hint,omitempty"`
+}

--- a/pkg/envelope/envelope_test.go
+++ b/pkg/envelope/envelope_test.go
@@ -1,0 +1,91 @@
+package envelope
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// marshal returns the compact JSON for v, failing the test on error.
+func marshal(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestDataShape(t *testing.T) {
+	type matter struct {
+		MatterID string `json:"matter_id"`
+	}
+	got := marshal(t, Data[matter]{Data: matter{MatterID: "m1"}})
+	want := `{"data":{"matter_id":"m1"}}`
+	if got != want {
+		t.Errorf("Data[T] = %s, want %s", got, want)
+	}
+}
+
+func TestDataEmptyRespShape(t *testing.T) {
+	got := marshal(t, Data[EmptyResp]{})
+	want := `{"data":{}}`
+	if got != want {
+		t.Errorf("Data[EmptyResp] = %s, want %s", got, want)
+	}
+}
+
+func TestCursorListShape(t *testing.T) {
+	got := marshal(t, CursorList[string]{
+		Data:       []string{"a", "b"},
+		Pagination: CursorPagination{HasMore: true, NextCursor: "tok"},
+	})
+	want := `{"data":["a","b"],"pagination":{"has_more":true,"next_cursor":"tok"}}`
+	if got != want {
+		t.Errorf("CursorList[T] = %s, want %s", got, want)
+	}
+}
+
+func TestCursorListLastPageOmitsNextCursor(t *testing.T) {
+	got := marshal(t, CursorList[string]{
+		Data:       []string{"a"},
+		Pagination: CursorPagination{HasMore: false},
+	})
+	// has_more must stay explicit even when false (R5: clients must not
+	// infer the end from an empty array); next_cursor is omitted.
+	want := `{"data":["a"],"pagination":{"has_more":false}}`
+	if got != want {
+		t.Errorf("CursorList last page = %s, want %s", got, want)
+	}
+}
+
+func TestOffsetListShape(t *testing.T) {
+	got := marshal(t, OffsetList[string]{
+		Data:       []string{"a"},
+		Pagination: OffsetPagination{Total: 42, Page: 2, PageSize: 20},
+	})
+	want := `{"data":["a"],"pagination":{"total":42,"page":2,"page_size":20}}`
+	if got != want {
+		t.Errorf("OffsetList[T] = %s, want %s", got, want)
+	}
+}
+
+func TestErrorShape(t *testing.T) {
+	got := marshal(t, Error{Error: ErrorBody{
+		Code:    "NOT_FOUND",
+		Message: "Matter not found",
+		Details: map[string]any{"resource": "matter"},
+		Hint:    "Verify the matter_id and try again.",
+	}})
+	want := `{"error":{"code":"NOT_FOUND","message":"Matter not found","details":{"resource":"matter"},"hint":"Verify the matter_id and try again."}}`
+	if got != want {
+		t.Errorf("Error = %s, want %s", got, want)
+	}
+}
+
+func TestErrorShapeOmitsEmptyDetailsAndHint(t *testing.T) {
+	got := marshal(t, Error{Error: ErrorBody{Code: "INTERNAL_ERROR", Message: "internal error"}})
+	want := `{"error":{"code":"INTERNAL_ERROR","message":"internal error"}}`
+	if got != want {
+		t.Errorf("Error minimal = %s, want %s", got, want)
+	}
+}

--- a/pkg/wkhttp/http.go
+++ b/pkg/wkhttp/http.go
@@ -80,6 +80,9 @@ func (c *Context) reset() {
 }
 
 // ResponseError ResponseError
+//
+// Legacy shape {"msg","status"}. New endpoints should respond errors via
+// RenderError / the injected ErrorRenderer (envelope.Error wire shape, R1).
 func (c *Context) ResponseError(err error) {
 	c.JSON(http.StatusBadRequest, gin.H{
 		"msg":    err.Error(),
@@ -120,6 +123,9 @@ func (c *Context) GetPage() (pageIndex int64, pageSize int64) {
 }
 
 // ResponseOK 返回成功
+//
+// Legacy shape {"status":200}. New endpoints should prefer ResponseEmpty
+// ({"data":{}}, R1); existing clients depend on this shape, do not change it.
 func (c *Context) ResponseOK() {
 	c.JSON(http.StatusOK, gin.H{
 		"status": http.StatusOK,
@@ -127,6 +133,9 @@ func (c *Context) ResponseOK() {
 }
 
 // Response Response
+//
+// Emits data bare (no envelope). New endpoints should prefer ResponseData /
+// ResponseCursor / ResponseOffset (R1 envelope wire shapes).
 func (c *Context) Response(data interface{}) {
 	c.JSON(http.StatusOK, data)
 }

--- a/pkg/wkhttp/response_envelope.go
+++ b/pkg/wkhttp/response_envelope.go
@@ -1,0 +1,105 @@
+package wkhttp
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/envelope"
+)
+
+// Envelope response helpers — emit the canonical OCTO API wire shapes
+// defined in pkg/envelope (spec rules R1/R5). New endpoints should use
+// these instead of the legacy Response / ResponseOK helpers; error
+// responses keep going through RenderError / the injected ErrorRenderer.
+//
+// Go methods cannot take type parameters, so the helpers accept `any`;
+// the emitted JSON is identical to the corresponding envelope generic
+// (swag annotations should reference envelope.Data[T] etc. for schemas).
+
+// R5 pagination parameter bounds.
+const (
+	defaultPageSize = 20
+	maxPageSize     = 100
+	defaultPage     = 1
+)
+
+// ResponseData replies 200 with the single-object envelope:
+// { "data": data } (R1).
+func (c *Context) ResponseData(data any) {
+	c.JSON(http.StatusOK, envelope.Data[any]{Data: data})
+}
+
+// ResponseCreated replies 201 with the single-object envelope:
+// { "data": data } (R1) — for create endpoints returning the new object.
+func (c *Context) ResponseCreated(data any) {
+	c.JSON(http.StatusCreated, envelope.Data[any]{Data: data})
+}
+
+// ResponseEmpty replies 200 with the empty success envelope:
+// { "data": {} } (R1) — for delete and state-machine actions.
+//
+// It intentionally does NOT reuse the legacy ResponseOK name: ResponseOK
+// emits {"status":200} and existing clients depend on that shape.
+func (c *Context) ResponseEmpty() {
+	c.JSON(http.StatusOK, envelope.Data[envelope.EmptyResp]{})
+}
+
+// ResponseCursor replies 200 with the cursor-paginated list envelope:
+// { "data": items, "pagination": {has_more, next_cursor} } (R1 + R5).
+// items must be a slice; pass an empty (non-nil) slice for no results so
+// the wire shows "data": [] instead of null. nextCursor is the opaque
+// token for the next page ("" on the last page).
+func (c *Context) ResponseCursor(items any, hasMore bool, nextCursor string) {
+	c.JSON(http.StatusOK, struct {
+		Data       any                       `json:"data"`
+		Pagination envelope.CursorPagination `json:"pagination"`
+	}{
+		Data:       items,
+		Pagination: envelope.CursorPagination{HasMore: hasMore, NextCursor: nextCursor},
+	})
+}
+
+// ResponseOffset replies 200 with the offset-paginated list envelope:
+// { "data": items, "pagination": {total, page, page_size} } (R1 + R5).
+// items must be a slice; pass an empty (non-nil) slice for no results.
+func (c *Context) ResponseOffset(items any, total int64, page, pageSize int) {
+	c.JSON(http.StatusOK, struct {
+		Data       any                       `json:"data"`
+		Pagination envelope.OffsetPagination `json:"pagination"`
+	}{
+		Data:       items,
+		Pagination: envelope.OffsetPagination{Total: total, Page: page, PageSize: pageSize},
+	})
+}
+
+// GetCursorParams reads the R5 cursor-mode query parameters: `cursor`
+// (opaque token, "" on first page) and `page_size` (default 20, capped
+// at 100; invalid values fall back to the default).
+func (c *Context) GetCursorParams() (cursor string, pageSize int) {
+	return c.Query("cursor"), c.pageSizeParam()
+}
+
+// GetOffsetParams reads the R5 offset-mode query parameters: `page`
+// (default 1) and `page_size` (default 20, capped at 100). Invalid
+// values fall back to the defaults.
+//
+// Unlike the legacy GetPage (page_index, default size 15), this follows
+// the R5 parameter contract.
+func (c *Context) GetOffsetParams() (page, pageSize int) {
+	page, _ = strconv.Atoi(c.Query("page"))
+	if page <= 0 {
+		page = defaultPage
+	}
+	return page, c.pageSizeParam()
+}
+
+func (c *Context) pageSizeParam() int {
+	size, _ := strconv.Atoi(c.Query("page_size"))
+	if size <= 0 {
+		return defaultPageSize
+	}
+	if size > maxPageSize {
+		return maxPageSize
+	}
+	return size
+}

--- a/pkg/wkhttp/response_envelope.go
+++ b/pkg/wkhttp/response_envelope.go
@@ -12,9 +12,11 @@ import (
 // these instead of the legacy Response / ResponseOK helpers; error
 // responses keep going through RenderError / the injected ErrorRenderer.
 //
-// Go methods cannot take type parameters, so the helpers accept `any`;
-// the emitted JSON is identical to the corresponding envelope generic
-// (swag annotations should reference envelope.Data[T] etc. for schemas).
+// Single-object helpers are Context methods taking `any`; list helpers
+// are package-level generic functions (methods cannot take type
+// parameters) so the slice type is compiler-checked and nil slices are
+// normalized to []. Swag annotations reference envelope.Data[T] /
+// envelope.CursorList[T] / envelope.OffsetList[T] for schemas.
 
 // R5 pagination parameter bounds.
 const (
@@ -46,14 +48,17 @@ func (c *Context) ResponseEmpty() {
 
 // ResponseCursor replies 200 with the cursor-paginated list envelope:
 // { "data": items, "pagination": {has_more, next_cursor} } (R1 + R5).
-// items must be a slice; pass an empty (non-nil) slice for no results so
-// the wire shows "data": [] instead of null. nextCursor is the opaque
-// token for the next page ("" on the last page).
-func (c *Context) ResponseCursor(items any, hasMore bool, nextCursor string) {
-	c.JSON(http.StatusOK, struct {
-		Data       any                       `json:"data"`
-		Pagination envelope.CursorPagination `json:"pagination"`
-	}{
+// nextCursor is the opaque token for the next page ("" on the last page).
+//
+// It is a package-level generic function (methods cannot take type
+// parameters): the []T parameter rejects non-slice payloads at compile
+// time, and a nil slice is normalized so the wire always shows
+// "data": [] instead of null.
+func ResponseCursor[T any](c *Context, items []T, hasMore bool, nextCursor string) {
+	if items == nil {
+		items = []T{}
+	}
+	c.JSON(http.StatusOK, envelope.CursorList[T]{
 		Data:       items,
 		Pagination: envelope.CursorPagination{HasMore: hasMore, NextCursor: nextCursor},
 	})
@@ -61,12 +66,12 @@ func (c *Context) ResponseCursor(items any, hasMore bool, nextCursor string) {
 
 // ResponseOffset replies 200 with the offset-paginated list envelope:
 // { "data": items, "pagination": {total, page, page_size} } (R1 + R5).
-// items must be a slice; pass an empty (non-nil) slice for no results.
-func (c *Context) ResponseOffset(items any, total int64, page, pageSize int) {
-	c.JSON(http.StatusOK, struct {
-		Data       any                       `json:"data"`
-		Pagination envelope.OffsetPagination `json:"pagination"`
-	}{
+// See ResponseCursor for why this is a function and how nil is handled.
+func ResponseOffset[T any](c *Context, items []T, total int64, page, pageSize int) {
+	if items == nil {
+		items = []T{}
+	}
+	c.JSON(http.StatusOK, envelope.OffsetList[T]{
 		Data:       items,
 		Pagination: envelope.OffsetPagination{Total: total, Page: page, PageSize: pageSize},
 	})

--- a/pkg/wkhttp/response_envelope_test.go
+++ b/pkg/wkhttp/response_envelope_test.go
@@ -52,23 +52,38 @@ func TestResponseEmpty(t *testing.T) {
 
 func TestResponseCursor(t *testing.T) {
 	ctx, w := newTestContext(t, "")
-	ctx.ResponseCursor([]testItem{{ID: "a"}, {ID: "b"}}, true, "tok")
+	ResponseCursor(ctx, []testItem{{ID: "a"}, {ID: "b"}}, true, "tok")
 	assertResponse(t, w, http.StatusOK,
 		`{"data":[{"id":"a"},{"id":"b"}],"pagination":{"has_more":true,"next_cursor":"tok"}}`)
 }
 
 func TestResponseCursorLastPage(t *testing.T) {
 	ctx, w := newTestContext(t, "")
-	ctx.ResponseCursor([]testItem{}, false, "")
+	ResponseCursor(ctx, []testItem{}, false, "")
 	// has_more stays explicit; next_cursor omitted; empty slice → "data":[]
+	assertResponse(t, w, http.StatusOK, `{"data":[],"pagination":{"has_more":false}}`)
+}
+
+func TestResponseCursorNilSliceNormalized(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	// nil is the default Go slice state (var s []T + no appends) — the
+	// helper must emit "data":[] rather than "data":null (R1).
+	ResponseCursor[testItem](ctx, nil, false, "")
 	assertResponse(t, w, http.StatusOK, `{"data":[],"pagination":{"has_more":false}}`)
 }
 
 func TestResponseOffset(t *testing.T) {
 	ctx, w := newTestContext(t, "")
-	ctx.ResponseOffset([]testItem{{ID: "a"}}, 42, 2, 20)
+	ResponseOffset(ctx, []testItem{{ID: "a"}}, 42, 2, 20)
 	assertResponse(t, w, http.StatusOK,
 		`{"data":[{"id":"a"}],"pagination":{"total":42,"page":2,"page_size":20}}`)
+}
+
+func TestResponseOffsetNilSliceNormalized(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	ResponseOffset[testItem](ctx, nil, 0, 1, 20)
+	assertResponse(t, w, http.StatusOK,
+		`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`)
 }
 
 func TestGetCursorParams(t *testing.T) {

--- a/pkg/wkhttp/response_envelope_test.go
+++ b/pkg/wkhttp/response_envelope_test.go
@@ -1,0 +1,122 @@
+package wkhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newTestContext returns a Context wired to a recorder, with an optional
+// request query string (e.g. "page=2&page_size=50").
+func newTestContext(t *testing.T, rawQuery string) (*Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(w)
+	ginCtx.Request = httptest.NewRequest(http.MethodGet, "/?"+rawQuery, nil)
+	return &Context{Context: ginCtx}, w
+}
+
+func assertResponse(t *testing.T, w *httptest.ResponseRecorder, wantStatus int, wantBody string) {
+	t.Helper()
+	if w.Code != wantStatus {
+		t.Errorf("status = %d, want %d", w.Code, wantStatus)
+	}
+	if got := w.Body.String(); got != wantBody {
+		t.Errorf("body = %s, want %s", got, wantBody)
+	}
+}
+
+type testItem struct {
+	ID string `json:"id"`
+}
+
+func TestResponseData(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	ctx.ResponseData(testItem{ID: "x"})
+	assertResponse(t, w, http.StatusOK, `{"data":{"id":"x"}}`)
+}
+
+func TestResponseCreated(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	ctx.ResponseCreated(testItem{ID: "x"})
+	assertResponse(t, w, http.StatusCreated, `{"data":{"id":"x"}}`)
+}
+
+func TestResponseEmpty(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	ctx.ResponseEmpty()
+	assertResponse(t, w, http.StatusOK, `{"data":{}}`)
+}
+
+func TestResponseCursor(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	ctx.ResponseCursor([]testItem{{ID: "a"}, {ID: "b"}}, true, "tok")
+	assertResponse(t, w, http.StatusOK,
+		`{"data":[{"id":"a"},{"id":"b"}],"pagination":{"has_more":true,"next_cursor":"tok"}}`)
+}
+
+func TestResponseCursorLastPage(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	ctx.ResponseCursor([]testItem{}, false, "")
+	// has_more stays explicit; next_cursor omitted; empty slice → "data":[]
+	assertResponse(t, w, http.StatusOK, `{"data":[],"pagination":{"has_more":false}}`)
+}
+
+func TestResponseOffset(t *testing.T) {
+	ctx, w := newTestContext(t, "")
+	ctx.ResponseOffset([]testItem{{ID: "a"}}, 42, 2, 20)
+	assertResponse(t, w, http.StatusOK,
+		`{"data":[{"id":"a"}],"pagination":{"total":42,"page":2,"page_size":20}}`)
+}
+
+func TestGetCursorParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		wantCur  string
+		wantSize int
+	}{
+		{"defaults", "", "", 20},
+		{"explicit", "cursor=tok&page_size=50", "tok", 50},
+		{"size capped at 100", "page_size=1000", "", 100},
+		{"invalid size falls back", "page_size=abc", "", 20},
+		{"zero size falls back", "page_size=0", "", 20},
+		{"negative size falls back", "page_size=-5", "", 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := newTestContext(t, tt.query)
+			cursor, size := ctx.GetCursorParams()
+			if cursor != tt.wantCur || size != tt.wantSize {
+				t.Errorf("GetCursorParams() = (%q, %d), want (%q, %d)", cursor, size, tt.wantCur, tt.wantSize)
+			}
+		})
+	}
+}
+
+func TestGetOffsetParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		wantPage int
+		wantSize int
+	}{
+		{"defaults", "", 1, 20},
+		{"explicit", "page=3&page_size=50", 3, 50},
+		{"zero page falls back", "page=0", 1, 20},
+		{"negative page falls back", "page=-2", 1, 20},
+		{"invalid page falls back", "page=abc", 1, 20},
+		{"size capped at 100", "page=2&page_size=999", 2, 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := newTestContext(t, tt.query)
+			page, size := ctx.GetOffsetParams()
+			if page != tt.wantPage || size != tt.wantSize {
+				t.Errorf("GetOffsetParams() = (%d, %d), want (%d, %d)", page, size, tt.wantPage, tt.wantSize)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The OCTO API spec (octo-openapi-dev-skill, rules R1/R2/R5) mandates canonical response wire shapes — `{"data": ...}` for 2xx, `{"data": [...], "pagination": {...}}` for lists, `{"error": {...}}` for failures — and the spectral toolchain now lint-blocks anything else. But octo-lib offers no envelope abstraction: octo-server's 444 handlers have no compliant type to reference (~793 bare legacy calls), and octo-matter / octo-smart-summary each hand-roll their own response helpers (matter's hand-rolled shapes happen to match the spec — evidence the shared abstraction is needed).

This PR ships the official implementation of the spec's "recommended unified response abstraction" (api-spec §B). Additive only: no existing method changes behavior.

## How

- **`pkg/envelope/envelope.go`** (new): dependency-free wire-shape types — `Data[T]`, `EmptyResp` (`Data[EmptyResp]` → `{"data":{}}`), `CursorList[T]` / `OffsetList[T]` with `CursorPagination` (`has_more`, omitempty `next_cursor`) / `OffsetPagination` (`total`, `page`, `page_size`), and `Error` / `ErrorBody` (`code`, `message`, omitempty `details` / `hint`). Gin-free on purpose so non-wkhttp services can reference the same types in swag annotations. The doc comment states the invariant: the contract is the wire shape, not the type name — lint validates structure.
- **`pkg/wkhttp/response_envelope.go`** (new):
  - Single-object `Context` methods: `ResponseData` (200), `ResponseCreated` (201), `ResponseEmpty` (200 `{"data":{}}`). `ResponseEmpty` is deliberately NOT named `ResponseOK`: the legacy `ResponseOK` emits `{"status":200}` and existing clients depend on it.
  - List helpers as package-level **generic functions** `ResponseCursor[T]` / `ResponseOffset[T]` (methods cannot take type parameters): `[]T` is compiler-checked, the canonical `envelope.CursorList[T]` / `OffsetList[T]` types are emitted directly (no hand-copied shape), and a nil slice — Go's default "no results" state — is normalized once at the helper so empty lists always render `"data":[]`, never `null` (R1).
  - R5 query readers `GetCursorParams` / `GetOffsetParams` (`page_size` default 20, capped at 100; `page` default 1; invalid values fall back).
- **`pkg/wkhttp/http.go`**: doc-comment guidance only on `Response` / `ResponseOK` / `ResponseError` pointing new code at the envelope helpers — no behavior change, no `Deprecated:` marker (it would instantly flag ~793 call sites in consumers' linters; formal deprecation is a later migration milestone).

### swag cross-module resolution (verified in octo-server)

Annotations like `@Success 200 {object} envelope.Data[string]` referencing this external module resolve under two conditions (verified with a temporary `replace` against this branch, swag v2.0.0-rc5):

| condition | result |
|---|---|
| no import, default flags | ❌ `cannot find type definition` |
| import + default flags | ❌ |
| **import (blank `_` import works) + `--parseDependencyLevel 1`** | ✅ schema generated with top-level `data`, passes the spectral R1 rule; ~1s extra gen time |

Follow-up (separate repo): add `--parseDependencyLevel 1` to the toolchain's `openapi-gen` target and document the blank-import pattern in api-spec §B/§E.

## Tests

- `pkg/envelope/envelope_test.go`: golden-JSON assertions pin every envelope byte-for-byte against api-spec §B, including `{"data":{}}` for `Data[EmptyResp]`, explicit `has_more:false` with omitted `next_cursor` on last pages, and `Error` with/without `details`/`hint`.
- `pkg/wkhttp/response_envelope_test.go`: per-helper status + exact-body assertions, **nil-slice normalization regressions for both list helpers** (`"data":[]`, not `null`), and table-driven default/cap/fallback cases for both parameter readers.
- Local run matches CI: `go test -race -count=1 ./pkg/envelope/ ./pkg/wkhttp/` green, `go vet ./...` clean, `CGO_ENABLED=0 go build ./...` ok.

Out of scope: migrating octo-server's 793 legacy call sites and adopting the package in octo-matter / octo-smart-summary — each repo migrates at its own pace per adoption.md.


Closes #75
