### PR TITLE
feat(contract): searchmsg Kafka contract + Kafka/ESIndex/Search config (YUJ-4530 phase 1)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -228,6 +228,28 @@ type Config struct {
 		SyncIntervalSecond int    // 同步消息间隔时间（单位秒）
 		SyncCount          int    // 每张表每次同步数量 默认100条
 	}
+	// ---------- 消息检索读侧后端切换（YUJ-4530 ETL→Kafka→ES indexer） ----------
+	// ReadBackend 选择检索读路径走哪个后端："zinc"（ZincSearch，默认/现状）或 "es"（OpenSearch + 查询侧 join）。
+	// 双写灰度期保持 ZincSearch 写入开启，仅切读；稳定后才下线 Zinc 写。
+	Search struct {
+		ReadBackend string // "zinc" | "es"，默认 "zinc"
+	}
+	// ---------- Kafka 共享总线（searchetl producer / es-indexer consumer） ----------
+	// 契约 struct 单一真源见 octo-lib contract/searchmsg。两侧 import 同一包。
+	Kafka struct {
+		On       bool     // 是否开启 Kafka 接入（producer 侧；关则 searchetl 仅空跑游标不投递）
+		Brokers  []string // broker 地址列表，如 ["kafka:9092"]
+		Topic    string   // 正文 topic，默认 octo.message.v1
+		DLQTopic string   // 死信 topic，默认 octo.message.v1.dlq
+	}
+	// ---------- es-indexer 的 OpenSearch 写入（独立镜像 binary 用，不复用 ElasticsearchURL/olivere v6） ----------
+	ESIndex struct {
+		On       bool     // 是否开启 OpenSearch bulk 写入
+		Addrs    []string // OpenSearch 节点地址列表，如 ["https://opensearch:9200"]
+		Username string   // 基础认证用户名
+		Password string   // 基础认证密码
+		Index    string   // 索引名（写读同名/或读用别名），默认 octo-message
+	}
 	// ---------- 群 ----------
 	Group struct {
 		SameDayCreateMaxCount     int  // 同一天创建群的最大数量
@@ -523,6 +545,12 @@ func New() *Config {
 		TablePartitionConfig: newTablePartitionConfig(),
 		ElasticsearchURL:     "http://elasticsearch:9200",
 	}
+	// 检索读侧默认走 ZincSearch（现状）；ES 路线由部署显式切换。
+	cfg.Search.ReadBackend = "zinc"
+	// Kafka / ESIndex 默认关闭、地址留空，由部署仓注入（octo-lib 不内置生产端点）。
+	cfg.Kafka.Topic = "octo.message.v1"
+	cfg.Kafka.DLQTopic = "octo.message.v1.dlq"
+	cfg.ESIndex.Index = "octo-message"
 
 	return cfg
 }
@@ -752,6 +780,19 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	c.ZincSearch.ZincPassword = c.getString("zincSearch.password", c.ZincSearch.ZincPassword)
 	c.ZincSearch.SyncIntervalSecond = c.getInt("zincSearch.syncIntervalSecond", c.ZincSearch.SyncIntervalSecond)
 	c.ZincSearch.SyncCount = c.getInt("zincSearch.syncCount", c.ZincSearch.SyncCount)
+	//#################### 检索读侧后端切换 ####################
+	c.Search.ReadBackend = c.getString("search.readBackend", c.Search.ReadBackend)
+	//#################### Kafka 共享总线 ####################
+	c.Kafka.On = c.getBool("kafka.on", c.Kafka.On)
+	c.Kafka.Brokers = c.getStringSlice("kafka.brokers", c.Kafka.Brokers)
+	c.Kafka.Topic = c.getString("kafka.topic", c.Kafka.Topic)
+	c.Kafka.DLQTopic = c.getString("kafka.dlqTopic", c.Kafka.DLQTopic)
+	//#################### es-indexer OpenSearch 写入 ####################
+	c.ESIndex.On = c.getBool("esIndex.on", c.ESIndex.On)
+	c.ESIndex.Addrs = c.getStringSlice("esIndex.addrs", c.ESIndex.Addrs)
+	c.ESIndex.Username = c.getString("esIndex.username", c.ESIndex.Username)
+	c.ESIndex.Password = c.getString("esIndex.password", c.ESIndex.Password)
+	c.ESIndex.Index = c.getString("esIndex.index", c.ESIndex.Index)
 	//#################### 群 #################
 	c.Group.SameDayCreateMaxCount = c.getInt("group.sameDayCreateMaxCount", c.Group.SameDayCreateMaxCount)
 	c.Group.CreateGroupVerifyFriendOn = c.getBool("group.createGroupVerifyFriendOn", c.Group.CreateGroupVerifyFriendOn)
@@ -835,6 +876,30 @@ func (c *Config) configureLog() {
 func (c *Config) getString(key string, defaultValue string) string {
 	v := c.vp.GetString(key)
 	if v == "" {
+		return defaultValue
+	}
+	return v
+}
+
+// getStringSlice 读取字符串列表配置。支持两种形态：YAML/JSON 数组（["a","b"]），以及
+// 单标量逗号分隔字符串（"a,b" —— env/简写常用）。viper.GetStringSlice 对逗号标量只按
+// 空白切分，不拆逗号，故这里先取标量再按逗号显式拆分兜底。为空（未配置）返回默认值。
+func (c *Config) getStringSlice(key string, defaultValue []string) []string {
+	// 优先取原始标量，命中含逗号的简写形态时显式拆分。
+	if raw := strings.TrimSpace(c.vp.GetString(key)); raw != "" && strings.Contains(raw, ",") {
+		parts := strings.Split(raw, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	v := c.vp.GetStringSlice(key)
+	if len(v) == 0 {
 		return defaultValue
 	}
 	return v

--- a/config/config_searchmsg_test.go
+++ b/config/config_searchmsg_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestSearchMsgDefaults 确认 Kafka/ESIndex/Search 默认值（off + 端点空 + topic/index 默认）。
+func TestSearchMsgDefaults(t *testing.T) {
+	cfg := New()
+	vp := viper.New()
+	cfg.ConfigureWithViper(vp)
+
+	if cfg.Search.ReadBackend != "zinc" {
+		t.Errorf("Search.ReadBackend default should be zinc, got %q", cfg.Search.ReadBackend)
+	}
+	if cfg.Kafka.On {
+		t.Errorf("Kafka.On default should be false")
+	}
+	if cfg.Kafka.Topic != "octo.message.v1" || cfg.Kafka.DLQTopic != "octo.message.v1.dlq" {
+		t.Errorf("Kafka topic defaults wrong: %q / %q", cfg.Kafka.Topic, cfg.Kafka.DLQTopic)
+	}
+	if len(cfg.Kafka.Brokers) != 0 {
+		t.Errorf("Kafka.Brokers default should be empty, got %v", cfg.Kafka.Brokers)
+	}
+	if cfg.ESIndex.On {
+		t.Errorf("ESIndex.On default should be false")
+	}
+	if cfg.ESIndex.Index != "octo-message" {
+		t.Errorf("ESIndex.Index default wrong: %q", cfg.ESIndex.Index)
+	}
+}
+
+// TestSearchMsgFromViperArray YAML 数组形态的 brokers/addrs 正确装载。
+func TestSearchMsgFromViperArray(t *testing.T) {
+	const yaml = `
+search:
+  readBackend: es
+kafka:
+  on: true
+  brokers:
+    - kafka1:9092
+    - kafka2:9092
+  topic: octo.message.v1
+  dlqTopic: octo.message.v1.dlq
+esIndex:
+  on: true
+  addrs:
+    - https://os1:9200
+    - https://os2:9200
+  username: admin
+  password: secret
+  index: octo-message
+`
+	vp := viper.New()
+	vp.SetConfigType("yaml")
+	if err := vp.ReadConfig(strings.NewReader(yaml)); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfg := New()
+	cfg.ConfigureWithViper(vp)
+
+	if cfg.Search.ReadBackend != "es" {
+		t.Errorf("ReadBackend = %q", cfg.Search.ReadBackend)
+	}
+	if !cfg.Kafka.On || len(cfg.Kafka.Brokers) != 2 || cfg.Kafka.Brokers[1] != "kafka2:9092" {
+		t.Errorf("Kafka brokers array wrong: %+v", cfg.Kafka.Brokers)
+	}
+	if !cfg.ESIndex.On || len(cfg.ESIndex.Addrs) != 2 || cfg.ESIndex.Addrs[0] != "https://os1:9200" {
+		t.Errorf("ESIndex addrs array wrong: %+v", cfg.ESIndex.Addrs)
+	}
+	if cfg.ESIndex.Username != "admin" || cfg.ESIndex.Password != "secret" {
+		t.Errorf("ESIndex auth wrong")
+	}
+}
+
+// TestSearchMsgFromViperCommaScalar 逗号分隔标量形态（env/简写）正确拆分为多元素切片。
+func TestSearchMsgFromViperCommaScalar(t *testing.T) {
+	vp := viper.New()
+	vp.Set("kafka.brokers", "kafka1:9092,kafka2:9092 , kafka3:9092")
+	vp.Set("esIndex.addrs", "https://os1:9200,https://os2:9200")
+
+	cfg := New()
+	cfg.ConfigureWithViper(vp)
+
+	if len(cfg.Kafka.Brokers) != 3 {
+		t.Fatalf("comma scalar brokers should split to 3, got %v", cfg.Kafka.Brokers)
+	}
+	if cfg.Kafka.Brokers[0] != "kafka1:9092" || cfg.Kafka.Brokers[2] != "kafka3:9092" {
+		t.Errorf("comma scalar brokers trim/split wrong: %v", cfg.Kafka.Brokers)
+	}
+	if len(cfg.ESIndex.Addrs) != 2 || cfg.ESIndex.Addrs[1] != "https://os2:9200" {
+		t.Errorf("comma scalar addrs wrong: %v", cfg.ESIndex.Addrs)
+	}
+}
+
+// TestSearchMsgEmptyKeepsDefault 未配置时保持代码默认（不被覆盖成空切片）。
+func TestSearchMsgEmptyKeepsDefault(t *testing.T) {
+	vp := viper.New()
+	cfg := New()
+	cfg.Kafka.Brokers = []string{"default:9092"}
+	cfg.ConfigureWithViper(vp)
+	if len(cfg.Kafka.Brokers) != 1 || cfg.Kafka.Brokers[0] != "default:9092" {
+		t.Errorf("empty config should keep default, got %v", cfg.Kafka.Brokers)
+	}
+}

--- a/contract/searchmsg/searchmsg.go
+++ b/contract/searchmsg/searchmsg.go
@@ -1,0 +1,66 @@
+// Package searchmsg 定义 octo-im 消息检索管线的 Kafka 契约 —— 单一真源。
+//
+// 该契约被两侧 import：octo-server 的 searchetl producer（往 Kafka 写），以及
+// 独立镜像 es-indexer consumer（从 Kafka 读、bulk 写 OpenSearch）。把 struct 放在
+// octo-lib（三仓共享 config 宿主）是硬要求：若放 octo-server，独立镜像的 es-indexer
+// 无法 import，会出现「编译过但运行期字段错位静默吃数据」。
+//
+// 设计纪律：
+//   - 字段名与 message 表/分表细节**解耦**：契约只描述「一条可检索的消息正文」，不暴露
+//     分表名、payload 内部结构、自增 id 等存储实现。未来源头从 ETL 升级到 Outbox+CDC，
+//     只需换「谁往 Kafka 写」，下游零改。
+//   - 带 SchemaVersion：consumer 见未知版本必须进 DLQ，**不得静默吃**。
+//   - 撤回/删除态**绝不进**该契约（路线甲：读时回 MySQL join 过滤）。这里只承载正文 +
+//     查询侧鉴权所需的可见性字段（ChannelID/ChannelType/FromUID）。
+package searchmsg
+
+// SchemaVersion 是当前正文契约的版本号。每次对 Message 做不兼容变更（删字段/改语义/
+// 改类型）必须 +1；consumer 收到非本值的消息一律进 DLQ，不得按旧结构强解。
+const SchemaVersion = 1
+
+// SourceETLMessageTable 是 ETL（读 message 表）阶段的 Source 取值。
+// 未来升级到 Outbox+CDC 时改该值（如 "cdc-binlog"），下游据此区分来源但不改解析逻辑。
+const SourceETLMessageTable = "etl-message-table"
+
+// Message 是 Kafka topic `octo.message.v1` 的正文契约（JSON 编解码）。
+//
+// Kafka key = MessageID（保证同一消息进同一分区、ES _id upsert 幂等）。
+// ES doc _id = MessageID。
+//
+// ⚠️ MessageID 显式为 string：对应 message 表的 VARCHAR(20) message_id 列。严禁参考
+// base/elastic stub 里的 uint64 类型（那是与实际 schema 双重错配的死代码）。
+type Message struct {
+	// SchemaVersion 契约版本，= 包级常量 SchemaVersion。consumer 必校验。
+	SchemaVersion int `json:"schema_version"`
+
+	// MessageID 消息唯一 id（= Kafka key = ES _id），对应 message 表 VARCHAR(20) message_id。
+	MessageID string `json:"message_id"`
+
+	// ChannelID 频道 id。群=groupNo；话题=groupNo____shortID；私聊=uid1@uid2 假频道 id。
+	// 查询侧鉴权 filter 与 DM 参与方判定依赖此字段，必存。
+	ChannelID string `json:"channel_id"`
+	// ChannelType 频道类型，见 octo-lib common.ChannelType（None/Person/Group/...）。
+	// 查询侧鉴权 filter 据此分流，必存。
+	ChannelType int `json:"channel_type"`
+	// FromUID 发送者 uid。
+	FromUID string `json:"from_uid"`
+
+	// Content 消息正文（从 payload 解出的可检索文本）。
+	// 当 RawExcluded=true（Signal 加密 / 非文本类）时为 nil（不算丢消息）。
+	Content *string `json:"content"`
+	// ContentType 消息内容类型（payload.type，规约为 int）。
+	ContentType int `json:"content_type"`
+
+	// RawExcluded 标记「已知不可索引类」：Signal 加密 DM（payload 非明文）或非文本结构化
+	// 内容。为 true 时 Content 置 nil，走正常流不进 DLQ —— 与「本应可解析却解析失败的真
+	// 异常」（进 DLQ）严格区分。
+	RawExcluded bool `json:"raw_excluded"`
+
+	// MsgTimestamp 消息发送时间（纪元秒，= message.timestamp）。
+	MsgTimestamp int64 `json:"msg_timestamp"`
+	// CreatedAt 落库时间（纪元秒，= UNIX_TIMESTAMP(message.created_at)）。
+	CreatedAt int64 `json:"created_at"`
+
+	// Source 数据来源标识，ETL 阶段 = SourceETLMessageTable；CDC 阶段换值，下游不改解析。
+	Source string `json:"source"`
+}

--- a/contract/searchmsg/searchmsg_test.go
+++ b/contract/searchmsg/searchmsg_test.go
@@ -1,0 +1,63 @@
+package searchmsg
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestMessageJSONRoundTrip 确认契约 JSON 字段名稳定、可往返编解码，且 Content 为
+// *string（RawExcluded 时序列化为 null，区别于空串）。
+func TestMessageJSONRoundTrip(t *testing.T) {
+	content := "hello 世界"
+	in := Message{
+		SchemaVersion: SchemaVersion,
+		MessageID:     "123456789012345678",
+		ChannelID:     "g_abc",
+		ChannelType:   2,
+		FromUID:       "u_1",
+		Content:       &content,
+		ContentType:   1,
+		RawExcluded:   false,
+		MsgTimestamp:  1700000000,
+		CreatedAt:     1700000001,
+		Source:        SourceETLMessageTable,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Message
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.MessageID != in.MessageID || out.ChannelType != in.ChannelType || out.Content == nil || *out.Content != content {
+		t.Fatalf("round-trip mismatch: %+v", out)
+	}
+	if out.Source != SourceETLMessageTable {
+		t.Fatalf("source mismatch: %q", out.Source)
+	}
+}
+
+// TestRawExcludedNullContent 确认 raw_excluded 时 content 序列化为 JSON null。
+func TestRawExcludedNullContent(t *testing.T) {
+	in := Message{
+		SchemaVersion: SchemaVersion,
+		MessageID:     "1",
+		RawExcluded:   true,
+		Content:       nil,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(raw["content"]) != "null" {
+		t.Fatalf("expected content null, got %s", raw["content"])
+	}
+	if string(raw["raw_excluded"]) != "true" {
+		t.Fatalf("expected raw_excluded true, got %s", raw["raw_excluded"])
+	}
+}


### PR DESCRIPTION
## What

Phase 1 (part 1 of 2) of the octo-im message → ETL → Kafka → ES-indexer search pipeline. This PR lands the **shared contract + config** in octo-lib — the single source of truth both sides import.

### Contract — `contract/searchmsg`
- `Message` struct = the JSON payload of Kafka topic `octo.message.v1`. Imported by **both** the producer (octo-server `searchetl`) and the standalone es-indexer consumer. Putting it here (not in octo-server) is a hard requirement: the es-indexer ships as a separate image and could not import an octo-server package — a mismatch would compile fine but silently eat data at runtime.
- Carries **body + visibility fields only** (`message_id`, `channel_id`, `channel_type`, `from_uid`, `content`, `content_type`, `raw_excluded`, timestamps, `source`). Revoke/delete state is **never** in the contract — it is filtered at read-time via a MySQL join (route 甲).
- `message_id` is explicitly `string` (matches `message.message_id VARCHAR(20)`; NOT the `uint64` of the dead `base/elastic` stub). `content` is `*string` so `raw_excluded` rows serialize as JSON `null` (distinct from empty string).
- `SchemaVersion` const: consumer must DLQ unknown versions, never strangle-parse.

### Config — `config/config.go`
- `Kafka{On,Brokers,Topic,DLQTopic}`, `ESIndex{On,Addrs,Username,Password,Index}`, `Search.ReadBackend` (`zinc`|`es`).
- Each field has a **matching viper loader line** + default (the `ElasticsearchURL` dead-config anti-pattern is exactly what this avoids). Kafka/ESIndex default **off** with empty endpoints (injected by deploy); read backend defaults to `zinc` (current behaviour unchanged).
- New `getStringSlice` helper handles both YAML arrays and comma-separated scalar (env shorthand).

## Out of scope (later phases)
No Kafka client, no producer/consumer logic, no es-indexer. This is types + config only.

## Verification
- `go build ./...` ✅ · `go vet ./config ./contract/...` ✅
- `go test ./config ./contract/...` ✅ (contract JSON round-trip + null-content + config defaults/array/comma-scalar/empty-keeps-default)
- /codex review: PASS ✅ (one P2 found — comma-scalar list split — fixed and re-verified)

## Merge order
⚠️ **Merge this FIRST.** octo-server's pin bump + contract import (phase 2) depends on this being merged so the go.mod pin can point at a real SHA (never an unmerged commit).

Part of YUJ-4530 (phase 1).
