### PR TITLE
feat(searchmsg): bump contract to v2 with SpaceID/Visibles/MessageSeq (sprint-w25)

### DIFF
--- a/contract/searchmsg/searchmsg.go
+++ b/contract/searchmsg/searchmsg.go
@@ -11,12 +11,18 @@
 //     只需换「谁往 Kafka 写」，下游零改。
 //   - 带 SchemaVersion：consumer 见未知版本必须进 DLQ，**不得静默吃**。
 //   - 撤回/删除态**绝不进**该契约（路线甲：读时回 MySQL join 过滤）。这里只承载正文 +
-//     查询侧鉴权所需的可见性字段（ChannelID/ChannelType/FromUID）。
+//     查询侧鉴权所需的可见性字段（ChannelID/ChannelType/FromUID/SpaceID/Visibles/MessageSeq）。
 package searchmsg
 
 // SchemaVersion 是当前正文契约的版本号。每次对 Message 做不兼容变更（删字段/改语义/
 // 改类型）必须 +1；consumer 收到非本值的消息一律进 DLQ，不得按旧结构强解。
-const SchemaVersion = 1
+//
+// v2（本次）：新增 reader 必读的安全/正确性字段 SpaceID / Visibles / MessageSeq。
+// 三字段与 octo-search-indexer esindex.Doc（spaceId/visibles/messageSeq）逐字段对齐：
+// indexer 的 SafetyFieldsSchemaVersion==2 + LiveContractCarriesSafetyFields()（仅判
+// searchmsg.SchemaVersion >= 2）据此在 indexer 重 pin 到本契约后自动解封实时写入封锁
+// （否则空 visibles → reader fail-OPEN，群系统消息普通成员能搜出群管才可见消息）。
+const SchemaVersion = 2
 
 // SourceETLMessageTable 是 ETL（读 message 表）阶段的 Source 取值。
 // 未来升级到 Outbox+CDC 时改该值（如 "cdc-binlog"），下游据此区分来源但不改解析逻辑。
@@ -45,6 +51,16 @@ type Message struct {
 	// FromUID 发送者 uid。
 	FromUID string `json:"from_uid"`
 
+	// SpaceID 空间隔离 id（对齐 indexer esindex.Doc.SpaceID `spaceId`）。p2p(DM) 召回
+	// 过滤依赖此字段；reader 对空 SpaceID 走 fail-closed（同 space 也 0 命中），故 producer
+	// 富化前实时路径写空属安全方向。omitempty 与 indexer 一致。
+	SpaceID string `json:"space_id,omitempty"`
+	// Visibles 群消息可见性白名单（对齐 indexer esindex.Doc.Visibles `visibles`）。群系统
+	// 消息「仅管理员可见」gate 强依赖此字段；reader 对空 Visibles 是 **fail-OPEN**（普通成员
+	// 能搜出群管才可见消息），故必须由 producer 富化后下游才能安全启用实时写入。omitempty 与
+	// indexer 一致。
+	Visibles []string `json:"visibles,omitempty"`
+
 	// Content 消息正文（从 payload 解出的可检索文本）。
 	// 当 RawExcluded=true（Signal 加密 / 非文本类）时为 nil（不算丢消息）。
 	Content *string `json:"content"`
@@ -60,6 +76,12 @@ type Message struct {
 	MsgTimestamp int64 `json:"msg_timestamp"`
 	// CreatedAt 落库时间（纪元秒，= UNIX_TIMESTAMP(message.created_at)）。
 	CreatedAt int64 `json:"created_at"`
+
+	// MessageSeq 频道内消息序号（取自 message.message_seq 列；对齐 indexer
+	// esindex.Doc.MessageSeq `messageSeq`，uint64 全精度）。reader channel_offset
+	// 「清空会话」gate（visibility.go）依赖此字段，缺/0 则保守隐藏（安全方向）。omitempty
+	// 与 indexer 一致。
+	MessageSeq uint64 `json:"message_seq,omitempty"`
 
 	// Source 数据来源标识，ETL 阶段 = SourceETLMessageTable；CDC 阶段换值，下游不改解析。
 	Source string `json:"source"`

--- a/contract/searchmsg/searchmsg_test.go
+++ b/contract/searchmsg/searchmsg_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 // TestMessageJSONRoundTrip 确认契约 JSON 字段名稳定、可往返编解码，且 Content 为
-// *string（RawExcluded 时序列化为 null，区别于空串）。
+// *string（RawExcluded 时序列化为 null，区别于空串）。同时覆盖 v2 新增的安全字段
+// SpaceID / Visibles / MessageSeq（encode→decode 字段不丢）。
 func TestMessageJSONRoundTrip(t *testing.T) {
 	content := "hello 世界"
 	in := Message{
@@ -15,11 +16,14 @@ func TestMessageJSONRoundTrip(t *testing.T) {
 		ChannelID:     "g_abc",
 		ChannelType:   2,
 		FromUID:       "u_1",
+		SpaceID:       "space_42",
+		Visibles:      []string{"u_admin1", "u_admin2"},
 		Content:       &content,
 		ContentType:   1,
 		RawExcluded:   false,
 		MsgTimestamp:  1700000000,
 		CreatedAt:     1700000001,
+		MessageSeq:    18446744073709551615, // max uint64: 全精度往返不截断
 		Source:        SourceETLMessageTable,
 	}
 	b, err := json.Marshal(in)
@@ -36,6 +40,93 @@ func TestMessageJSONRoundTrip(t *testing.T) {
 	if out.Source != SourceETLMessageTable {
 		t.Fatalf("source mismatch: %q", out.Source)
 	}
+	if out.SpaceID != in.SpaceID {
+		t.Fatalf("space_id mismatch: got %q want %q", out.SpaceID, in.SpaceID)
+	}
+	if out.MessageSeq != in.MessageSeq {
+		t.Fatalf("message_seq mismatch: got %d want %d", out.MessageSeq, in.MessageSeq)
+	}
+	if len(out.Visibles) != len(in.Visibles) {
+		t.Fatalf("visibles length mismatch: got %v want %v", out.Visibles, in.Visibles)
+	}
+	for i := range in.Visibles {
+		if out.Visibles[i] != in.Visibles[i] {
+			t.Fatalf("visibles[%d] mismatch: got %q want %q", i, out.Visibles[i], in.Visibles[i])
+		}
+	}
+}
+
+// TestSchemaVersionIsV2 锁定契约版本：携带安全字段（SpaceID/Visibles/MessageSeq）的
+// 契约必须为 v2，indexer LiveContractCarriesSafetyFields()（判 SchemaVersion>=2）据此解封。
+func TestSchemaVersionIsV2(t *testing.T) {
+	if SchemaVersion != 2 {
+		t.Fatalf("SchemaVersion = %d, want 2 (safety-fields contract)", SchemaVersion)
+	}
+}
+
+// TestSafetyFieldsOmitEmpty 确认三个安全字段在空值时按 omitempty 省略（与 indexer
+// esindex.Doc 一致），避免在 producer 未富化时往 ES 写空 keyword/数组扰乱 mapping。
+func TestSafetyFieldsOmitEmpty(t *testing.T) {
+	in := Message{
+		SchemaVersion: SchemaVersion,
+		MessageID:     "1",
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"space_id", "visibles", "message_seq"} {
+		if _, ok := raw[k]; ok {
+			t.Fatalf("expected %q omitted when empty, got %s", k, raw[k])
+		}
+	}
+}
+
+// TestSafetyFieldsWireKeys 锁定三个安全字段的 Kafka 线格 JSON key 为 snake_case
+// （与契约其余 11 个字段一致；producer json.Marshal(Message) 投 Kafka，consumer
+// json.Unmarshal 读回 Message，再由 indexer DocFromMessage 在 Go 字段层映射到
+// esindex.Doc 的 camelCase）。这是两条独立线格的边界——Kafka=snake_case、ES=camelCase——
+// 故契约侧必须 snake_case，不能照搬 esindex.Doc 的 spaceId/messageSeq。
+func TestSafetyFieldsWireKeys(t *testing.T) {
+	visibles := []string{"u_admin1"}
+	in := Message{
+		SchemaVersion: SchemaVersion,
+		MessageID:     "1",
+		SpaceID:       "space_1",
+		Visibles:      visibles,
+		MessageSeq:    7,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"space_id", "visibles", "message_seq"} {
+		if _, ok := raw[k]; !ok {
+			t.Fatalf("expected snake_case wire key %q present, got keys %v", k, keysOf(raw))
+		}
+	}
+	// 反向：不得出现 esindex.Doc 的 camelCase key（防止误把 ES 形态搬进 Kafka 契约）。
+	for _, k := range []string{"spaceId", "messageSeq"} {
+		if _, ok := raw[k]; ok {
+			t.Fatalf("unexpected camelCase key %q in Kafka contract (must be snake_case)", k)
+		}
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
 }
 
 // TestRawExcludedNullContent 确认 raw_excluded 时 content 序列化为 JSON null。


### PR DESCRIPTION
## What

Bump the `searchmsg` Kafka contract to **SchemaVersion 2** and add three reader-required safety/correctness fields to `Message`:

| Go field | JSON (Kafka wire) | type | purpose |
|---|---|---|---|
| `SpaceID` | `space_id,omitempty` | `string` | space isolation; reader fail-closed on empty for p2p |
| `Visibles` | `visibles,omitempty` | `[]string` | group-message visibility allowlist; reader **fail-OPEN** on empty (the gap this closes) |
| `MessageSeq` | `message_seq,omitempty` | `uint64` | channel-offset / clear-conversation gate |

## Why

The downstream indexer's `esindex.Doc` already declares these three fields and gates real-time write on them (`SafetyFieldsSchemaVersion == 2`, checked via `searchmsg.SchemaVersion >= 2`). Until the contract carries them, the real-time path writes empty `visibles`, which the reader treats as fail-OPEN (normal members can search admin-only group system messages). Bumping the contract is the prerequisite that lets the indexer repin and auto-unblock that path.

## Alignment

Field **Go types** match `esindex.Doc` exactly (`string` / `[]string` / `uint64`), so the indexer's `DocFromMessage` maps with no casts after it repins.

**JSON tags stay snake_case** to match the existing 11 contract fields (`message_id`, `channel_id`, `msg_timestamp`, …). `esindex.Doc`'s camelCase form (`spaceId`, `messageSeq`) is a **separate ES wire boundary**: the consumer unmarshals Kafka bytes into `searchmsg.Message` (snake_case), then `DocFromMessage` bridges at the Go-field level into `Doc` (camelCase) for OpenSearch. The two encodings are intentionally distinct and never pass JSON through directly.

## Scope

Contract-only. No producer/indexer change is required to compile — the fields are additive with `omitempty`. Producer enrichment and indexer repin land separately.

## Tests

`go test ./contract/searchmsg/...` green:
- round-trip over all three fields (incl. max `uint64`, no float truncation)
- `SchemaVersion == 2` lock
- `omitempty` omits empty safety fields
- snake_case wire-key assertion (rejects accidental camelCase)
<!-- retrigger sprint 1781762794 -->