### PR TITLE
fix(log): synchronize lazy logger init to remove data race

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -43,9 +43,9 @@ func Configure(opts *Options) {
 	configureLocked(opts)
 }
 
-// configureLocked builds the loggers and publishes them as one set. Callers must
-// hold configMu.
-func configureLocked(opts *Options) {
+// configureLocked builds the loggers, publishes them as one set, and returns it.
+// Callers must hold configMu.
+func configureLocked(opts *Options) *loggerSet {
 	atom.SetLevel(opts.Level)
 
 	stdoutCore := zapcore.NewCore(
@@ -114,12 +114,14 @@ func configureLocked(opts *Options) {
 		warn = zap.New(warnCore)
 	}
 
-	loggers.Store(&loggerSet{
+	set := &loggerSet{
 		infoLogger:  info,
 		errorLogger: errLogger,
 		warnLogger:  warn,
 		testLogger:  test,
-	})
+	}
+	loggers.Store(set)
+	return set
 }
 
 // current returns the published logger set, lazily configuring it with default
@@ -132,11 +134,11 @@ func current() *loggerSet {
 		return ls
 	}
 	configMu.Lock()
-	if loggers.Load() == nil {
-		configureLocked(NewOptions())
+	defer configMu.Unlock()
+	if ls := loggers.Load(); ls != nil { // another goroutine configured while we waited
+		return ls
 	}
-	configMu.Unlock()
-	return loggers.Load()
+	return configureLocked(NewOptions())
 }
 
 func newEncoderConfig() zapcore.EncoderConfig {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -11,23 +13,51 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-var logger *zap.Logger
-var errorLogger *zap.Logger
-var warnLogger *zap.Logger
-var testLogger *zap.Logger
-var atom = zap.NewAtomicLevel()
+// loggerSet bundles the configured loggers so they can be published as a single
+// unit. Readers load the whole set through an atomic.Pointer, so they observe
+// either a fully-built set or none at all — never a half-initialized one. This
+// mirrors the boxed atomic.Pointer pattern already used in pkg/wkhttp.
+type loggerSet struct {
+	infoLogger  *zap.Logger
+	errorLogger *zap.Logger
+	warnLogger  *zap.Logger
+	testLogger  *zap.Logger
+}
 
+// The package loggers are configured lazily on first use (or eagerly via
+// Configure). configMu serializes (re)configuration so concurrent first-time
+// callers cannot race on the lazy init, while loggers is read lock-free on the
+// hot logging path once configured. atom is shared by the cores and is itself
+// goroutine-safe.
+var (
+	configMu sync.Mutex
+	loggers  atomic.Pointer[loggerSet]
+	atom     = zap.NewAtomicLevel()
+)
+
+// Configure (re)configures the package loggers. It is safe to call concurrently
+// and alongside lazy first-use initialization.
 func Configure(opts *Options) {
+	configMu.Lock()
+	defer configMu.Unlock()
+	configureLocked(opts)
+}
+
+// configureLocked builds the loggers and publishes them as one set. Callers must
+// hold configMu.
+func configureLocked(opts *Options) {
 	atom.SetLevel(opts.Level)
-	core := zapcore.NewCore(
+
+	stdoutCore := zapcore.NewCore(
 		zapcore.NewJSONEncoder(newEncoderConfig()),
 		zapcore.NewMultiWriteSyncer(zapcore.AddSync(os.Stdout)),
 		atom,
 	)
+	var test *zap.Logger
 	if opts.LineNum {
-		testLogger = zap.New(core, zap.AddCaller())
+		test = zap.New(stdoutCore, zap.AddCaller())
 	} else {
-		testLogger = zap.New(core)
+		test = zap.New(stdoutCore)
 	}
 
 	infoWriter := zapcore.AddSync(&lumberjack.Logger{
@@ -36,15 +66,16 @@ func Configure(opts *Options) {
 		MaxBackups: 3,
 		MaxAge:     28, // days
 	})
-	core = zapcore.NewCore(
+	infoCore := zapcore.NewCore(
 		zapcore.NewJSONEncoder(newEncoderConfig()),
 		zapcore.NewMultiWriteSyncer(zapcore.AddSync(os.Stdout), zapcore.AddSync(infoWriter)),
 		atom,
 	)
+	var info *zap.Logger
 	if opts.LineNum {
-		logger = zap.New(core, zap.AddCaller())
+		info = zap.New(infoCore, zap.AddCaller())
 	} else {
-		logger = zap.New(core)
+		info = zap.New(infoCore)
 	}
 
 	errorWriter := zapcore.AddSync(&lumberjack.Logger{
@@ -53,15 +84,16 @@ func Configure(opts *Options) {
 		MaxBackups: 3,
 		MaxAge:     28, // days
 	})
-	core = zapcore.NewCore(
+	errorCore := zapcore.NewCore(
 		zapcore.NewJSONEncoder(newEncoderConfig()),
 		zapcore.NewMultiWriteSyncer(zapcore.AddSync(os.Stdout), zapcore.AddSync(errorWriter)),
 		zap.ErrorLevel,
 	)
+	var errLogger *zap.Logger
 	if opts.LineNum {
-		errorLogger = zap.New(core, zap.AddCaller())
+		errLogger = zap.New(errorCore, zap.AddCaller())
 	} else {
-		errorLogger = zap.New(core)
+		errLogger = zap.New(errorCore)
 	}
 
 	warnWriter := zapcore.AddSync(&lumberjack.Logger{
@@ -70,17 +102,41 @@ func Configure(opts *Options) {
 		MaxBackups: 3,
 		MaxAge:     28, // days
 	})
-	core = zapcore.NewCore(
+	warnCore := zapcore.NewCore(
 		zapcore.NewJSONEncoder(newEncoderConfig()),
 		zapcore.NewMultiWriteSyncer(zapcore.AddSync(os.Stdout), zapcore.AddSync(warnWriter)),
 		zap.WarnLevel,
 	)
+	var warn *zap.Logger
 	if opts.LineNum {
-		warnLogger = zap.New(core, zap.AddCaller())
+		warn = zap.New(warnCore, zap.AddCaller())
 	} else {
-		warnLogger = zap.New(core)
+		warn = zap.New(warnCore)
 	}
 
+	loggers.Store(&loggerSet{
+		infoLogger:  info,
+		errorLogger: errLogger,
+		warnLogger:  warn,
+		testLogger:  test,
+	})
+}
+
+// current returns the published logger set, lazily configuring it with default
+// options on first use. Because the set is published as a single atomic pointer,
+// the returned value always has every logger built — there is no window where one
+// logger is set and another is still nil. The lock-free fast path keeps the hot
+// logging path free of contention once configured.
+func current() *loggerSet {
+	if ls := loggers.Load(); ls != nil {
+		return ls
+	}
+	configMu.Lock()
+	if loggers.Load() == nil {
+		configureLocked(NewOptions())
+	}
+	configMu.Unlock()
+	return loggers.Load()
 }
 
 func newEncoderConfig() zapcore.EncoderConfig {
@@ -110,38 +166,22 @@ func timeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 
 // Info Info
 func Info(msg string, fields ...zap.Field) {
-
-	if logger == nil {
-		Configure(NewOptions())
-	}
-	logger.Info(msg, fields...)
+	current().infoLogger.Info(msg, fields...)
 }
 
 // Debug Debug
 func Debug(msg string, fields ...zap.Field) {
-
-	if logger == nil {
-		Configure(NewOptions())
-	}
-	logger.Debug(msg, fields...)
-
+	current().infoLogger.Debug(msg, fields...)
 }
 
 // Error Error
 func Error(msg string, fields ...zap.Field) {
-	if errorLogger == nil {
-		Configure(NewOptions())
-	}
-	errorLogger.Error(msg, fields...)
+	current().errorLogger.Error(msg, fields...)
 }
 
 // Warn Warn
 func Warn(msg string, fields ...zap.Field) {
-
-	if warnLogger == nil {
-		Configure(NewOptions())
-	}
-	warnLogger.Warn(msg, fields...)
+	current().warnLogger.Warn(msg, fields...)
 }
 
 // Log Log

--- a/pkg/log/logger_concurrent_test.go
+++ b/pkg/log/logger_concurrent_test.go
@@ -37,6 +37,10 @@ func TestConcurrentLazyInit(t *testing.T) {
 	}
 	close(start)
 	wg.Wait()
+
+	if loggers.Load() == nil {
+		t.Fatal("loggers should be configured after concurrent lazy-init use")
+	}
 }
 
 // TestConcurrentConfigureAndLog ensures explicit Configure is safe alongside
@@ -63,4 +67,8 @@ func TestConcurrentConfigureAndLog(t *testing.T) {
 	}
 	close(start)
 	wg.Wait()
+
+	if loggers.Load() == nil {
+		t.Fatal("loggers should be configured after concurrent Configure/log use")
+	}
 }

--- a/pkg/log/logger_concurrent_test.go
+++ b/pkg/log/logger_concurrent_test.go
@@ -1,0 +1,66 @@
+package log
+
+import (
+	"sync"
+	"testing"
+)
+
+// resetLoggers forces the lazy-init path by clearing the published logger set,
+// independent of test ordering or -shuffle. It is white-box (same package) on
+// purpose: the globals are unexported.
+func resetLoggers() {
+	configMu.Lock()
+	defer configMu.Unlock()
+	loggers.Store(nil)
+}
+
+// TestConcurrentLazyInit reproduces issue #77: before the sync fix, the first
+// concurrent log calls raced on the unsynchronized lazy init (log.Warn reading a
+// global that Configure was concurrently writing). Run with -race to guard
+// against regressions.
+func TestConcurrentLazyInit(t *testing.T) {
+	resetLoggers()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all at once to maximize contention on first-use init
+			Info("concurrent info")
+			Warn("concurrent warn")
+			Error("concurrent error")
+			Debug("concurrent debug")
+		}()
+	}
+	close(start)
+	wg.Wait()
+}
+
+// TestConcurrentConfigureAndLog ensures explicit Configure is safe alongside
+// concurrent logging (the lazy init and an explicit reconfigure both publish the
+// globals; they must not race).
+func TestConcurrentConfigureAndLog(t *testing.T) {
+	resetLoggers()
+
+	const goroutines = 25
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			Configure(NewOptions())
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			Warn("racing with configure")
+		}()
+	}
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

`pkg/log` configured its package-global loggers lazily on first use **without synchronization**. When the first log calls in a process happened concurrently (before anything called `Configure`), goroutines raced on the `if X == nil { Configure() }` lazy init: one read the nil global while another wrote it inside `Configure`. `go test -race` flagged this (e.g. `modules/notify` fanning out concurrent `Warn` calls) and it intermittently failed CI.

Closes #77.

## Root cause

```go
var logger, errorLogger, warnLogger *zap.Logger // unguarded globals

func Warn(msg string, fields ...zap.Field) {
    if warnLogger == nil {      // read of the global
        Configure(NewOptions()) // Configure writes the globals
    }
    warnLogger.Warn(msg, fields...)
}
```

Concurrent first-time callers read a global (the nil check) while another goroutine wrote it inside `Configure()` → data race. `Info` / `Debug` / `Error` / `Warn` all shared the same unguarded pattern.

- **Production: none.** `octo-server` calls `log.Configure()` once at startup (single-threaded) before any concurrency, so subsequent logging is concurrent read-only.
- **CI/tests: real, flaky.** Test servers don't pre-call `Configure`, so the globals stay nil until the first (possibly concurrent) log call; with `-shuffle=on` the race appears intermittently.

## Fix

- Serialize (re)configuration with a `sync.Mutex` (`configMu`); `Configure` delegates to an internal `configureLocked` that holds the lock.
- Publish all loggers as one `loggerSet` through a **single `atomic.Pointer`**, so the hot logging path is a single lock-free atomic load and readers always observe a fully-built set — never a half-initialized one.
- `current()` performs the one-time lazy init under `configMu` (double-checked) and returns the published set; `Info` / `Debug` / `Error` / `Warn` read from it.

Publishing one set (rather than several independent atomics gated by a single-logger sentinel) keeps the sentinel and the reads on the **same pointer**, so correctness no longer depends on the order in which loggers are stored. This mirrors the boxed `atomic.Pointer` pattern already used in `pkg/wkhttp`.

The public API (`Configure` / `Info` / `Debug` / `Error` / `Warn` / `TLog`) is unchanged, and lazy first-use plus explicit `Configure` semantics are preserved.

## Testing

- New `pkg/log/logger_concurrent_test.go` reproduces the race under `-race` by forcing the lazy path from many goroutines concurrently, and alongside an explicit `Configure`. It fails (DATA RACE) on the old code and passes on the fix.
- `go test -race -shuffle=on` — green across 20+ repeated runs (`-count=5` per run).
- `go build ./...` and `go vet ./pkg/log/` clean.

## Notes

- During review, `testLogger` was found to be pre-existing dead code (written, never read). Left untouched here to keep this change scoped to the concurrency fix; suggest a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpoBeeNmZ1aH6gKjcWe7fx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpoBeeNmZ1aH6gKjcWe7fx)_