### PR TITLE
feat(searchmsg): shared fail-closed ExtractVisibility for producer + indexer

### DIFF
--- a/contract/searchmsg/visibility.go
+++ b/contract/searchmsg/visibility.go
@@ -1,0 +1,114 @@
+package searchmsg
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrVisibilityFailClosed 表示一条**非加密**消息的可见性无法被可信解析，调用方必须
+// fail-closed（落 DLQ，绝不进正文 topic）。判 errors.Is(err, ErrVisibilityFailClosed)
+// 可与「真序列化/IO 错误」区分，但当前所有 fail-closed 返回都包它，调用方只需判 err!=nil。
+var ErrVisibilityFailClosed = errors.New("searchmsg: visibility fail-closed")
+
+// ExtractVisibility 从一条消息的**原始 payload 字节**解析 reader 鉴权所需的可见性字段
+// （SpaceID / Visibles）——这是 octo-im 消息检索管线 fail-closed 可见性口径的**单一真源**。
+//
+// 三方共用（强制 (a) 抽 octo-lib，禁 (b) 各仓重实现，防 #1124 口径分叉）：
+//   - octo-server searchetl producer（实时 + backfill 富化时填 searchmsg.Message.SpaceID/Visibles）
+//   - octo-search-indexer backfill（docFromRow 富化 esindex.Doc.SpaceID/Visibles）
+//   - 未来 reader 侧若需从 payload 复核可见性
+//
+// 仅对**非加密**消息调用：Signal 加密 DM 的 payload 是密文，调用方应在调用前判加密并直接
+// 走 raw_excluded（SpaceID/Visibles 留空 = reader fail-closed，安全方向），绝不把密文当损坏
+// JSON 喂进来误判。
+//
+// 🔴 fail-closed 返回值契约（reader visibility.go 对空 Visibles 是 **fail-OPEN**：普通成员
+// 能搜出「仅指定成员可见」的群定向系统消息，正是 #1124 泄漏）：
+//
+//	① payload 顶层不是 JSON 对象（损坏 / 截断 / 数组 / 标量）
+//	    → err != nil。可见性整体不可信，调用方 fail-closed（DLQ）。
+//	② payload 是对象，但**不含** visibles 键
+//	    → spaceID（容忍解析）, nil, nil。这是「广播给频道全员」的正常消息（普通群聊正文、
+//	      GroupCreate/GroupUpdate 等无定向系统消息）——reader 无 gate 即放行属预期，**安全**。
+//	③ payload 含 visibles 键，但解析不出 **≥1 个有效字符串 UID**
+//	    （visibles 为 null / 非数组 / 空数组 [] / 数组里全是非字符串或空串元素）
+//	    → err != nil。**关键**：visibles 键的「存在」即表示「本消息本应受白名单约束」（octo-lib
+//	      config/msg_group.go 仅在 GroupMemberBeRemove/Invite/Exit 等定向系统消息上写 visibles=
+//	      subscribers，且发送前已保证 subscribers 非空）。若键在却解析为空，说明白名单已损坏/漂移
+//	      → 必须 fail-closed（DLQ），绝不写空 Visibles 让 reader fail-OPEN。这正是 ReviewBot
+//	      YUJ-4953 钉死的「valid-but-empty visibles 也要拦」口径，比旧 indexer extractVisibility
+//	      （把空数组当广播放行）更严。
+//	④ payload 含合法 visibles（≥1 个有效字符串 UID）
+//	    → spaceID, visibles, nil。
+//
+// space_id 的类型**容忍**：仅当 JSON 字符串时取值，其余类型（数字 / 对象 / null / 上游漂移）
+// 退化为空 spaceID（reader 对 p2p 空 spaceID 走 fail-closed，安全方向）——绝不让 space_id 的
+// 怪异类型炸掉整条 payload 的解析、连累合法 visibles 被清空（这是 V3b fail-OPEN 的历史根因）。
+func ExtractVisibility(payload []byte) (spaceID string, visibles []string, err error) {
+	// 先把 payload 解成顶层对象（容忍每个字段各自的 JSON 类型）。顶层不是对象才是真正
+	// 「可见性不可信」→ fail-closed。单个字段的类型怪异不在此判死。
+	var top map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	if derr := dec.Decode(&top); derr != nil {
+		return "", nil, fmt.Errorf("%w: payload not a JSON object: %v", ErrVisibilityFailClosed, derr)
+	}
+	// 顶层 `null` 会 Decode 成 nil map 而**不**报错——它不是合法的可见性对象，必须 fail-closed
+	// （否则落进「无 visibles 键」分支被当广播放行 = fail-OPEN）。
+	if top == nil {
+		return "", nil, fmt.Errorf("%w: payload is JSON null, not an object", ErrVisibilityFailClosed)
+	}
+	// 拒绝尾部多余字节（如 `{...} garbage`、`{...}]`、`{...}}`）：合法 payload 必须**恰好**是
+	// 一个 JSON 对象，其后只能是空白 + EOF。不能用 dec.More()——它把 `]`/`}` 当「无下一元素」
+	// 返回 false，会放过 `{...}]` 这类损坏 payload（落进「无 visibles 键」分支被当广播 = fail-OPEN）。
+	// 改为再 Decode 一次并要求返回 io.EOF：任何可再解出的值或非 EOF 错误都说明有尾部残留 → fail-closed。
+	var trailing json.RawMessage
+	if derr := dec.Decode(&trailing); !errors.Is(derr, io.EOF) {
+		return "", nil, fmt.Errorf("%w: payload has trailing data after JSON object", ErrVisibilityFailClosed)
+	}
+
+	// space_id：容忍类型——仅 JSON 字符串取值，其余类型留空（不报错、不连累 visibles）。
+	if raw, ok := top["space_id"]; ok {
+		var s string
+		if uerr := json.Unmarshal(raw, &s); uerr == nil {
+			spaceID = s
+		}
+		// 非字符串 space_id（数字 / 对象 / null）→ spaceID 留空（reader p2p fail-closed）。
+	}
+
+	// visibles：键**不存在** = 广播消息（无 gate 意图），放行进正文流（安全：本就发给全员）。
+	rawVis, ok := top["visibles"]
+	if !ok {
+		return spaceID, nil, nil
+	}
+
+	// 键存在即表示「本应受白名单约束」。从这里起，任何「解析不出 ≥1 个有效 UID」都 fail-closed。
+	// null：键在却无值 = 白名单损坏/漂移 → fail-closed（绝不当广播放行）。
+	if string(bytes.TrimSpace(rawVis)) == "null" {
+		return "", nil, fmt.Errorf("%w: visibles present but null", ErrVisibilityFailClosed)
+	}
+	var elems []json.RawMessage
+	if uerr := json.Unmarshal(rawVis, &elems); uerr != nil {
+		// 非数组（对象 / 标量 / 字符串）= 白名单结构损坏 → fail-closed。
+		return "", nil, fmt.Errorf("%w: visibles is not a JSON array: %v", ErrVisibilityFailClosed, uerr)
+	}
+	out := make([]string, 0, len(elems))
+	for _, raw := range elems {
+		var s string
+		if uerr := json.Unmarshal(raw, &s); uerr != nil {
+			// 与 octo-server visiblesAllows 口径一致：非字符串元素跳过（不当作有效约束）。
+			continue
+		}
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		// visibles 键在、却解析不出任何有效 UID（空数组 [] / 全非字符串 / 全空串）
+		// = valid-but-empty 白名单损坏 → fail-closed（ReviewBot YUJ-4953 钉死口径）。
+		return "", nil, fmt.Errorf("%w: visibles present but resolves to zero valid UIDs", ErrVisibilityFailClosed)
+	}
+	return spaceID, out, nil
+}

--- a/contract/searchmsg/visibility_test.go
+++ b/contract/searchmsg/visibility_test.go
@@ -1,0 +1,62 @@
+package searchmsg
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// TestExtractVisibility_SharedVectors 跑共享 fail-closed 向量集，锁口径单一真源。
+// octo-server searchetl 与 octo-search-indexer backfill 各自 import 同一组向量跑同样断言，
+// 防 #1124 在不同仓重新分叉（验收门 (ii)）。
+func TestExtractVisibility_SharedVectors(t *testing.T) {
+	for _, v := range FailClosedVisibilityVectors() {
+		v := v
+		t.Run(v.Name, func(t *testing.T) {
+			spaceID, visibles, err := ExtractVisibility(v.Payload)
+			if v.WantErr {
+				if err == nil {
+					t.Fatalf("%s: want fail-closed err, got spaceID=%q visibles=%v", v.Name, spaceID, visibles)
+				}
+				if !errors.Is(err, ErrVisibilityFailClosed) {
+					t.Fatalf("%s: err must wrap ErrVisibilityFailClosed, got %v", v.Name, err)
+				}
+				// fail-closed 时绝不返回任何可见性值（防调用方误用）。
+				if spaceID != "" || visibles != nil {
+					t.Fatalf("%s: fail-closed must return empty values, got spaceID=%q visibles=%v", v.Name, spaceID, visibles)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s: want ok, got err %v", v.Name, err)
+			}
+			if spaceID != v.WantSpaceID {
+				t.Fatalf("%s: spaceID=%q want %q", v.Name, spaceID, v.WantSpaceID)
+			}
+			if !reflect.DeepEqual(visibles, v.WantVisibles) {
+				t.Fatalf("%s: visibles=%v want %v", v.Name, visibles, v.WantVisibles)
+			}
+		})
+	}
+}
+
+// TestExtractVisibility_EmptyVisiblesFailClosed 单独钉死 ReviewBot 最强调的口径：
+// 非加密群消息 visibles **valid-but-empty**（键在、空数组）必须 fail-closed，绝不放空 visibles。
+func TestExtractVisibility_EmptyVisiblesFailClosed(t *testing.T) {
+	_, _, err := ExtractVisibility([]byte(`{"content":"x","visibles":[]}`))
+	if err == nil {
+		t.Fatal("valid-but-empty visibles MUST fail-closed (else reader fail-OPEN, #1124)")
+	}
+}
+
+// TestExtractVisibility_NoVisiblesIsBroadcast 钉死：无 visibles 键 = 广播，放行不报错。
+// 否则全部正常群聊正文会被灌进 DLQ。
+func TestExtractVisibility_NoVisiblesIsBroadcast(t *testing.T) {
+	spaceID, visibles, err := ExtractVisibility([]byte(`{"type":1,"content":"normal chat"}`))
+	if err != nil {
+		t.Fatalf("broadcast (no visibles key) must pass, got %v", err)
+	}
+	if spaceID != "" || visibles != nil {
+		t.Fatalf("broadcast must yield empty spaceID + nil visibles, got %q %v", spaceID, visibles)
+	}
+}

--- a/contract/searchmsg/visibility_vectors.go
+++ b/contract/searchmsg/visibility_vectors.go
@@ -1,0 +1,150 @@
+package searchmsg
+
+// 本文件是**非测试**源码（不带 _test.go 后缀），故可被任意外部仓 import。它把
+// ExtractVisibility 的 fail-closed 测试向量收敛为单一真源，供三方共用，锁口径：
+//   - octo-server  modules/searchetl 的 producer fail-closed 单测
+//   - octo-search-indexer backfill 富化路径单测
+// 两侧跑**同一组**向量（验收门 (ii)：同口径锁），防 #1124 在不同仓重新分叉。
+
+// VisibilityVector 是一条 ExtractVisibility 的期望行为向量。
+type VisibilityVector struct {
+	// Name 用例名（断言失败时定位）。
+	Name string
+	// Payload 原始消息 payload 字节（非加密）。
+	Payload []byte
+	// WantErr 期望 fail-closed（true → 调用方必须落 DLQ，绝不进正文 topic）。
+	WantErr bool
+	// WantSpaceID / WantVisibles 仅在 WantErr=false 时校验。WantVisibles=nil 表示
+	// 「广播消息，无白名单」（reader 无 gate 放行属预期安全行为）。
+	WantSpaceID  string
+	WantVisibles []string
+}
+
+// FailClosedVisibilityVectors 返回锁口径的共享测试向量集。
+//
+// 安全核心（ReviewBot YUJ-4953 裁决逐字钉死，不可弱化）：
+//   - 非加密群消息 visibles **解析失败** → fail-closed（DLQ）。
+//   - 非加密群消息 visibles **valid-but-empty**（键在但空数组 / null / 全非字符串）
+//     → 同样 fail-closed（DLQ）。population 校验主落点在此，空数组也要拦。
+//   - visibles 键**缺失** = 广播消息 → 放行（visibles=nil），这是正常群聊正文/无定向系统
+//     消息，reader 无 gate 放行属预期；若把它也拦死会把全部正常消息灌进 DLQ。
+//   - space_id 非字符串类型不连累 visibles（V3b fail-OPEN 根因隔离）。
+func FailClosedVisibilityVectors() []VisibilityVector {
+	return []VisibilityVector{
+		// ---- 放行类（visibles 键缺失 = 广播；或含合法白名单）----
+		{
+			Name:         "broadcast/no_visibles_key",
+			Payload:      []byte(`{"type":1,"content":"hello group"}`),
+			WantErr:      false,
+			WantVisibles: nil,
+		},
+		{
+			Name:         "broadcast/no_visibles_with_space_id",
+			Payload:      []byte(`{"type":1,"content":"hi","space_id":"space_42"}`),
+			WantErr:      false,
+			WantSpaceID:  "space_42",
+			WantVisibles: nil,
+		},
+		{
+			Name:         "valid/visibles_single_uid",
+			Payload:      []byte(`{"type":99,"content":"you were removed","visibles":["u_alice"]}`),
+			WantErr:      false,
+			WantVisibles: []string{"u_alice"},
+		},
+		{
+			Name:         "valid/visibles_multi_uid_with_space",
+			Payload:      []byte(`{"content":"x","visibles":["u_a","u_b"],"space_id":"s1"}`),
+			WantErr:      false,
+			WantSpaceID:  "s1",
+			WantVisibles: []string{"u_a", "u_b"},
+		},
+		{
+			// space_id 非字符串（数字）必须退化为空 spaceID，且**绝不**连累合法 visibles。
+			Name:         "tolerant/space_id_number_does_not_drop_visibles",
+			Payload:      []byte(`{"content":"x","space_id":123,"visibles":["u_a","u_b"]}`),
+			WantErr:      false,
+			WantSpaceID:  "",
+			WantVisibles: []string{"u_a", "u_b"},
+		},
+		{
+			// 数组里混入非字符串元素：跳过非法元素，仍保留有效 UID（与 visiblesAllows 一致）。
+			Name:         "valid/visibles_mixed_skips_non_string",
+			Payload:      []byte(`{"content":"x","visibles":["u_a",123,null,"u_b"]}`),
+			WantErr:      false,
+			WantVisibles: []string{"u_a", "u_b"},
+		},
+
+		// ---- fail-closed 类：解析失败（unparseable）----
+		{
+			Name:    "failclosed/payload_not_json",
+			Payload: []byte(`{not valid json`),
+			WantErr: true,
+		},
+		{
+			Name:    "failclosed/payload_top_level_array",
+			Payload: []byte(`["a","b"]`),
+			WantErr: true,
+		},
+		{
+			Name:    "failclosed/payload_top_level_scalar",
+			Payload: []byte(`"just a string"`),
+			WantErr: true,
+		},
+		{
+			// 顶层 JSON null：Decode 成 nil map 不报错，但不是合法可见性对象 → fail-closed。
+			Name:    "failclosed/payload_json_null",
+			Payload: []byte(`null`),
+			WantErr: true,
+		},
+		{
+			// 尾部多余字节：Decode 只吃第一个值，残留 = payload 不是恰好一个对象 → fail-closed。
+			Name:    "failclosed/payload_trailing_data",
+			Payload: []byte(`{"content":"x"} garbage`),
+			WantErr: true,
+		},
+		{
+			// 尾部多余 `]`：dec.More() 会误判为「无更多」，必须靠二次 Decode 要求 EOF 才能拦住。
+			Name:    "failclosed/payload_trailing_bracket",
+			Payload: []byte(`{"content":"x"}]`),
+			WantErr: true,
+		},
+		{
+			// 尾部多余 `}`：同上，损坏 payload 不可信 → fail-closed。
+			Name:    "failclosed/payload_trailing_brace",
+			Payload: []byte(`{"content":"x"}}`),
+			WantErr: true,
+		},
+		{
+			Name:    "failclosed/visibles_object_not_array",
+			Payload: []byte(`{"content":"x","visibles":{"u_a":true}}`),
+			WantErr: true,
+		},
+		{
+			Name:    "failclosed/visibles_string_not_array",
+			Payload: []byte(`{"content":"x","visibles":"u_a"}`),
+			WantErr: true,
+		},
+
+		// ---- fail-closed 类：valid-but-empty（ReviewBot 特别强调，空数组也要拦）----
+		{
+			Name:    "failclosed/visibles_empty_array",
+			Payload: []byte(`{"content":"x","visibles":[]}`),
+			WantErr: true,
+		},
+		{
+			Name:    "failclosed/visibles_null",
+			Payload: []byte(`{"content":"x","visibles":null}`),
+			WantErr: true,
+		},
+		{
+			Name:    "failclosed/visibles_all_non_string",
+			Payload: []byte(`{"content":"x","visibles":[123,456,null]}`),
+			WantErr: true,
+		},
+		{
+			Name:    "failclosed/visibles_all_empty_string",
+			Payload: []byte(`{"content":"x","visibles":["",""]}`),
+			WantErr: true,
+		},
+	}
+}


### PR DESCRIPTION
## What

Extract the message-visibility parser into the shared `searchmsg` contract as `ExtractVisibility`, so all three sides of the search pipeline use **one** source of truth:

- octo-server `modules/searchetl` producer (real-time + backfill enrichment)
- octo-search-indexer `internal/backfill` enrichment
- any future reader-side re-check

Previously the logic lived only in octo-search-indexer (`internal/backfill/doc_enrich.go::extractVisibility`, a Go-internal package the independent indexer image could not share with the server). Re-implementing it in octo-server would fork the security semantic across repos — the root cause class behind the #1124 over-exposure.

## Fail-closed semantics (unchanged intent, now stricter + shared)

The reader treats **empty `visibles` as fail-OPEN** (no gate). So:

| payload | result |
|---|---|
| not a JSON object (corrupt/array/scalar) | **error → caller DLQs** |
| object, **no** `visibles` key | broadcast → pass (`visibles=nil`) |
| `visibles` present but `null` / non-array / `[]` / all-non-string / all-empty | **error → caller DLQs** (valid-but-empty also blocked) |
| `visibles` with ≥1 valid string UID | pass |

`space_id` is type-tolerant: only taken when a JSON string, otherwise degrades to empty **without** dropping a legitimate `visibles` (isolates the V3b fail-OPEN root cause).

This is stricter than the old indexer parser, which let a valid-but-empty `[]` through as a broadcast — exactly the gap ReviewBot YUJ-4953 flagged.

## Shared test vectors

`FailClosedVisibilityVectors()` ships as non-test source so octo-server and octo-search-indexer both import and run the **identical** vector set, locking one semantic across repos.

## Test

`go build ./...`, `go vet ./contract/...`, `go test ./contract/searchmsg/` all green.

Part of the Route A real-time unblock chain (producer enrichment depends on this).
