### PR TITLE
chore(config): remove dead Kafka producer config struct

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -234,14 +234,6 @@ type Config struct {
 	Search struct {
 		ReadBackend string // "zinc" | "es"，默认 "zinc"
 	}
-	// ---------- Kafka 共享总线（searchetl producer / es-indexer consumer） ----------
-	// 契约 struct 单一真源见 octo-lib contract/searchmsg。两侧 import 同一包。
-	Kafka struct {
-		On       bool     // 是否开启 Kafka 接入（producer 侧；关则 searchetl 仅空跑游标不投递）
-		Brokers  []string // broker 地址列表，如 ["kafka:9092"]
-		Topic    string   // 正文 topic，默认 octo.message.v1
-		DLQTopic string   // 死信 topic，默认 octo.message.v1.dlq
-	}
 	// ---------- es-indexer 的 OpenSearch 写入（独立镜像 binary 用，不复用 ElasticsearchURL/olivere v6） ----------
 	ESIndex struct {
 		On       bool     // 是否开启 OpenSearch bulk 写入
@@ -547,9 +539,7 @@ func New() *Config {
 	}
 	// 检索读侧默认走 ZincSearch（现状）；ES 路线由部署显式切换。
 	cfg.Search.ReadBackend = "zinc"
-	// Kafka / ESIndex 默认关闭、地址留空，由部署仓注入（octo-lib 不内置生产端点）。
-	cfg.Kafka.Topic = "octo.message.v1"
-	cfg.Kafka.DLQTopic = "octo.message.v1.dlq"
+	// ESIndex 默认关闭、地址留空，由部署仓注入（octo-lib 不内置生产端点）。
 	cfg.ESIndex.Index = "octo-message"
 
 	return cfg
@@ -782,11 +772,6 @@ func (c *Config) ConfigureWithViper(vp *viper.Viper) {
 	c.ZincSearch.SyncCount = c.getInt("zincSearch.syncCount", c.ZincSearch.SyncCount)
 	//#################### 检索读侧后端切换 ####################
 	c.Search.ReadBackend = c.getString("search.readBackend", c.Search.ReadBackend)
-	//#################### Kafka 共享总线 ####################
-	c.Kafka.On = c.getBool("kafka.on", c.Kafka.On)
-	c.Kafka.Brokers = c.getStringSlice("kafka.brokers", c.Kafka.Brokers)
-	c.Kafka.Topic = c.getString("kafka.topic", c.Kafka.Topic)
-	c.Kafka.DLQTopic = c.getString("kafka.dlqTopic", c.Kafka.DLQTopic)
 	//#################### es-indexer OpenSearch 写入 ####################
 	c.ESIndex.On = c.getBool("esIndex.on", c.ESIndex.On)
 	c.ESIndex.Addrs = c.getStringSlice("esIndex.addrs", c.ESIndex.Addrs)

--- a/config/config_searchmsg_test.go
+++ b/config/config_searchmsg_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// TestSearchMsgDefaults 确认 Kafka/ESIndex/Search 默认值（off + 端点空 + topic/index 默认）。
+// TestSearchMsgDefaults 确认 ESIndex/Search 默认值（off + 端点空 + index 默认）。
 func TestSearchMsgDefaults(t *testing.T) {
 	cfg := New()
 	vp := viper.New()
@@ -15,15 +15,6 @@ func TestSearchMsgDefaults(t *testing.T) {
 
 	if cfg.Search.ReadBackend != "zinc" {
 		t.Errorf("Search.ReadBackend default should be zinc, got %q", cfg.Search.ReadBackend)
-	}
-	if cfg.Kafka.On {
-		t.Errorf("Kafka.On default should be false")
-	}
-	if cfg.Kafka.Topic != "octo.message.v1" || cfg.Kafka.DLQTopic != "octo.message.v1.dlq" {
-		t.Errorf("Kafka topic defaults wrong: %q / %q", cfg.Kafka.Topic, cfg.Kafka.DLQTopic)
-	}
-	if len(cfg.Kafka.Brokers) != 0 {
-		t.Errorf("Kafka.Brokers default should be empty, got %v", cfg.Kafka.Brokers)
 	}
 	if cfg.ESIndex.On {
 		t.Errorf("ESIndex.On default should be false")
@@ -33,18 +24,11 @@ func TestSearchMsgDefaults(t *testing.T) {
 	}
 }
 
-// TestSearchMsgFromViperArray YAML 数组形态的 brokers/addrs 正确装载。
+// TestSearchMsgFromViperArray YAML 数组形态的 addrs 正确装载。
 func TestSearchMsgFromViperArray(t *testing.T) {
 	const yaml = `
 search:
   readBackend: es
-kafka:
-  on: true
-  brokers:
-    - kafka1:9092
-    - kafka2:9092
-  topic: octo.message.v1
-  dlqTopic: octo.message.v1.dlq
 esIndex:
   on: true
   addrs:
@@ -65,9 +49,6 @@ esIndex:
 	if cfg.Search.ReadBackend != "es" {
 		t.Errorf("ReadBackend = %q", cfg.Search.ReadBackend)
 	}
-	if !cfg.Kafka.On || len(cfg.Kafka.Brokers) != 2 || cfg.Kafka.Brokers[1] != "kafka2:9092" {
-		t.Errorf("Kafka brokers array wrong: %+v", cfg.Kafka.Brokers)
-	}
 	if !cfg.ESIndex.On || len(cfg.ESIndex.Addrs) != 2 || cfg.ESIndex.Addrs[0] != "https://os1:9200" {
 		t.Errorf("ESIndex addrs array wrong: %+v", cfg.ESIndex.Addrs)
 	}
@@ -79,18 +60,11 @@ esIndex:
 // TestSearchMsgFromViperCommaScalar 逗号分隔标量形态（env/简写）正确拆分为多元素切片。
 func TestSearchMsgFromViperCommaScalar(t *testing.T) {
 	vp := viper.New()
-	vp.Set("kafka.brokers", "kafka1:9092,kafka2:9092 , kafka3:9092")
 	vp.Set("esIndex.addrs", "https://os1:9200,https://os2:9200")
 
 	cfg := New()
 	cfg.ConfigureWithViper(vp)
 
-	if len(cfg.Kafka.Brokers) != 3 {
-		t.Fatalf("comma scalar brokers should split to 3, got %v", cfg.Kafka.Brokers)
-	}
-	if cfg.Kafka.Brokers[0] != "kafka1:9092" || cfg.Kafka.Brokers[2] != "kafka3:9092" {
-		t.Errorf("comma scalar brokers trim/split wrong: %v", cfg.Kafka.Brokers)
-	}
 	if len(cfg.ESIndex.Addrs) != 2 || cfg.ESIndex.Addrs[1] != "https://os2:9200" {
 		t.Errorf("comma scalar addrs wrong: %v", cfg.ESIndex.Addrs)
 	}
@@ -100,9 +74,9 @@ func TestSearchMsgFromViperCommaScalar(t *testing.T) {
 func TestSearchMsgEmptyKeepsDefault(t *testing.T) {
 	vp := viper.New()
 	cfg := New()
-	cfg.Kafka.Brokers = []string{"default:9092"}
+	cfg.ESIndex.Addrs = []string{"default:9200"}
 	cfg.ConfigureWithViper(vp)
-	if len(cfg.Kafka.Brokers) != 1 || cfg.Kafka.Brokers[0] != "default:9092" {
-		t.Errorf("empty config should keep default, got %v", cfg.Kafka.Brokers)
+	if len(cfg.ESIndex.Addrs) != 1 || cfg.ESIndex.Addrs[0] != "default:9200" {
+		t.Errorf("empty config should keep default, got %v", cfg.ESIndex.Addrs)
 	}
 }


### PR DESCRIPTION
## Summary

Removes the dead `cfg.Kafka` config struct from `config/config.go`. The in-repo Kafka producer has been retired in prior phases, and nothing in this repo (or its known consumers) reads `cfg.Kafka` anymore — it is pure dead configuration.

## Changes

- Remove the `Kafka struct { On / Brokers / Topic / DLQTopic }` definition.
- Remove its default-value assignments in `New()` (`Topic` / `DLQTopic`).
- Remove its viper binding block in `ConfigureWithViper` (`kafka.on/brokers/topic/dlqTopic`).
- Drop the now-orphaned `kafka.*` assertions in `config_searchmsg_test.go`, keeping full coverage for the retained `Search` and `ESIndex` config.

## Not touched

- `contract/searchmsg` — the shared message-pipeline wire contract (single source of truth for producer + es-indexer) is **not** modified.
- `pkg/redis`, `common`, and all other packages are untouched.
- No runtime behavior changes; this is a dead-config-only cleanup with zero production risk.

## Verification

- `CGO_ENABLED=0 go build ./...` → exit 0
- `go vet ./...` → exit 0
- `go test ./...` → all PASS (incl. `contract/searchmsg`)
- Repo-wide grep confirms no remaining `cfg.Kafka` / `c.Kafka` references (only the protected `contract/searchmsg` package mentions Kafka, by design).