### PR TITLE
docs(searchmsg): fix producer attribution in package comment

### DIFF
--- a/contract/searchmsg/searchmsg.go
+++ b/contract/searchmsg/searchmsg.go
@@ -1,8 +1,8 @@
 // Package searchmsg 定义 octo-im 消息检索管线的 Kafka 契约 —— 单一真源。
 //
-// 该契约被两侧 import：octo-server 的 searchetl producer（往 Kafka 写），以及
-// 独立镜像 es-indexer consumer（从 Kafka 读、bulk 写 OpenSearch）。把 struct 放在
-// octo-lib（三仓共享 config 宿主）是硬要求：若放 octo-server，独立镜像的 es-indexer
+// 该契约被两侧 import：独立镜像 octo-search-indexer 的 producer（往 Kafka 写），以及
+// es-indexer consumer（从 Kafka 读、bulk 写 OpenSearch）。把 struct 放在
+// octo-lib（三仓共享 config 宿主）是硬要求：若放 octo-search-indexer，独立镜像的 es-indexer
 // 无法 import，会出现「编译过但运行期字段错位静默吃数据」。
 //
 // 设计纪律：

--- a/contract/searchmsg/searchmsg.go
+++ b/contract/searchmsg/searchmsg.go
@@ -1,9 +1,11 @@
 // Package searchmsg 定义 octo-im 消息检索管线的 Kafka 契约 —— 单一真源。
 //
-// 该契约被两侧 import：独立镜像 octo-search-indexer 的 producer（往 Kafka 写），以及
-// es-indexer consumer（从 Kafka 读、bulk 写 OpenSearch）。把 struct 放在
-// octo-lib（三仓共享 config 宿主）是硬要求：若放 octo-search-indexer，独立镜像的 es-indexer
-// 无法 import，会出现「编译过但运行期字段错位静默吃数据」。
+// 该契约跨仓共同 import：octo-search-indexer 镜像的多个命令（searchetl-producer 往 Kafka 写、
+// es-indexer 从 Kafka 读并 bulk 写 OpenSearch、backfill 历史富化），以及 octo-server 读侧
+// （query-time join 过滤 revoked/deleted）与共享单测向量。把 struct 放在 octo-lib（三仓共享
+// config/契约宿主）是硬要求：契约既被 octo-search-indexer 又被 octo-server 跨仓共用，唯有放在
+// 两仓都能 import 的 octo-lib，字段语义才有单一真源；否则各仓重定义必然「编译过但运行期字段
+// 错位静默吃数据」。
 //
 // 设计纪律：
 //   - 字段名与 message 表/分表细节**解耦**：契约只描述「一条可检索的消息正文」，不暴露

--- a/contract/searchmsg/visibility.go
+++ b/contract/searchmsg/visibility.go
@@ -17,8 +17,8 @@ var ErrVisibilityFailClosed = errors.New("searchmsg: visibility fail-closed")
 // （SpaceID / Visibles）——这是 octo-im 消息检索管线 fail-closed 可见性口径的**单一真源**。
 //
 // 三方共用（强制 (a) 抽 octo-lib，禁 (b) 各仓重实现，防 #1124 口径分叉）：
-//   - octo-server searchetl producer（实时 + backfill 富化时填 searchmsg.Message.SpaceID/Visibles）
-//   - octo-search-indexer backfill（docFromRow 富化 esindex.Doc.SpaceID/Visibles）
+//   - octo-search-indexer 的 producer（实时富化时填 searchmsg.Message.SpaceID/Visibles）
+//   - octo-search-indexer 的 backfill（docFromRow 历史富化 esindex.Doc.SpaceID/Visibles）
 //   - 未来 reader 侧若需从 payload 复核可见性
 //
 // 仅对**非加密**消息调用：Signal 加密 DM 的 payload 是密文，调用方应在调用前判加密并直接

--- a/contract/searchmsg/visibility_test.go
+++ b/contract/searchmsg/visibility_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestExtractVisibility_SharedVectors 跑共享 fail-closed 向量集，锁口径单一真源。
-// octo-server searchetl 与 octo-search-indexer backfill 各自 import 同一组向量跑同样断言，
+// octo-search-indexer 的 producer 与 backfill 各自 import 同一组向量跑同样断言，
 // 防 #1124 在不同仓重新分叉（验收门 (ii)）。
 func TestExtractVisibility_SharedVectors(t *testing.T) {
 	for _, v := range FailClosedVisibilityVectors() {

--- a/contract/searchmsg/visibility_vectors.go
+++ b/contract/searchmsg/visibility_vectors.go
@@ -2,7 +2,7 @@ package searchmsg
 
 // 本文件是**非测试**源码（不带 _test.go 后缀），故可被任意外部仓 import。它把
 // ExtractVisibility 的 fail-closed 测试向量收敛为单一真源，供三方共用，锁口径：
-//   - octo-server  modules/searchetl 的 producer fail-closed 单测
+//   - octo-search-indexer 的 producer 富化路径 fail-closed 单测
 //   - octo-search-indexer backfill 富化路径单测
 // 两侧跑**同一组**向量（验收门 (ii)：同口径锁），防 #1124 在不同仓重新分叉。
 


### PR DESCRIPTION
## What

Fix a stale attribution in the `contract/searchmsg` package comment.

The comment described the Kafka producer as octo-server's `searchetl`,
but the producer now lives in the standalone `octo-search-indexer`
image's `internal/producer`. The old wording could mislead readers into
thinking the producer is still built into octo-server.

## Changes

- Corrected the producer attribution in the package doc comment
  (octo-server → octo-search-indexer), and updated the matching
  counterfactual in the placement rationale.

## Out of scope

- No changes to any `searchmsg` struct, field, or `SchemaVersion`
  (the contract itself is untouched).
- Comment-only edit; no code logic, DB, or deployment changes.

## Verification

- `git diff` contains only the package comment in
  `contract/searchmsg/searchmsg.go` (3 lines).
- `go build ./... && go vet ./...` → exit 0.
