### PR TITLE
feat(searchmsg): add optional RawPayload field for CDC-style consumer projection

### DIFF
--- a/contract/searchmsg/searchmsg.go
+++ b/contract/searchmsg/searchmsg.go
@@ -16,6 +16,8 @@
 //     查询侧鉴权所需的可见性字段（ChannelID/ChannelType/FromUID/SpaceID/Visibles/MessageSeq）。
 package searchmsg
 
+import "encoding/json"
+
 // SchemaVersion 是当前正文契约的版本号。每次对 Message 做不兼容变更（删字段/改语义/
 // 改类型）必须 +1；consumer 收到非本值的消息一律进 DLQ，不得按旧结构强解。
 //
@@ -68,6 +70,21 @@ type Message struct {
 	Content *string `json:"content"`
 	// ContentType 消息内容类型（payload.type，规约为 int）。
 	ContentType int `json:"content_type"`
+
+	// RawPayload 是非加密消息的原始 payload 整包（明文 JSON）。方案 B（CDC 式写入）：
+	// producer 退化为只发原始 payload，正文投影 + visibility fail-closed 解析全部下沉到
+	// es-indexer 消费侧（由它从本字段解析）。
+	//
+	// 设计：
+	//   - 用 json.RawMessage（内联存原始 JSON 字节）而非 []byte：[]byte 经 Go json 编码会
+	//     转成 base64 字符串、膨胀 ~33%，挤压 Kafka 1MiB 写侧硬限；json.RawMessage 零膨胀且
+	//     Kafka 侧人工排障可读。
+	//   - 加密消息（RawExcluded=true 的 Signal DM）此字段为 nil（密文不外发），消费侧据
+	//     「len(RawPayload)==0 且 RawExcluded==true」识别加密分支、绝不把密文喂进解析器。
+	//   - 增量 optional（omitempty）：不 bump SchemaVersion（consumer 严格相等校验，bump 会让
+	//     在飞 v2 消息全进 DLQ）。在飞老 v2 消息无此字段，消费侧据「len(RawPayload)>0」分流到
+	//     新形态投影、否则回退旧 Content/ContentType 路径。
+	RawPayload json.RawMessage `json:"raw_payload,omitempty"`
 
 	// RawExcluded 标记「已知不可索引类」：Signal 加密 DM（payload 非明文）或非文本结构化
 	// 内容。为 true 时 Content 置 nil，走正常流不进 DLQ —— 与「本应可解析却解析失败的真

--- a/contract/searchmsg/searchmsg_test.go
+++ b/contract/searchmsg/searchmsg_test.go
@@ -129,6 +129,66 @@ func keysOf(m map[string]json.RawMessage) []string {
 	return ks
 }
 
+// TestRawPayloadRoundTrip 确认方案 B 新增的 RawPayload（json.RawMessage）原始 payload 整包
+// 经 Kafka 线格 JSON 往返不丢、不二次转义（json.RawMessage 内联原始字节，零 base64 膨胀），
+// 线格 key 为 snake_case raw_payload。
+func TestRawPayloadRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{"type":2,"name":"合同.png","url":"https://x/y.png"}`)
+	in := Message{
+		SchemaVersion: SchemaVersion,
+		MessageID:     "1",
+		RawPayload:    raw,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(b, &top); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, ok := top["raw_payload"]
+	if !ok {
+		t.Fatalf("expected snake_case wire key raw_payload present, got keys %v", keysOf(top))
+	}
+	// 内联存原始 JSON 对象（不是 base64 字符串）：首字节应为 '{'，不带引号包裹。
+	if len(got) == 0 || got[0] != '{' {
+		t.Fatalf("raw_payload must be inlined JSON (json.RawMessage), got %s", got)
+	}
+	var out Message
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if string(out.RawPayload) != string(raw) {
+		t.Fatalf("RawPayload round-trip mismatch: got %s want %s", out.RawPayload, raw)
+	}
+}
+
+// TestRawPayloadOmitEmpty 确认 RawPayload 为空时按 omitempty 省略（在飞老 v2 / 加密消息
+// 不带该字段，消费侧据其有无分流）。
+func TestRawPayloadOmitEmpty(t *testing.T) {
+	in := Message{SchemaVersion: SchemaVersion, MessageID: "1"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := raw["raw_payload"]; ok {
+		t.Fatalf("expected raw_payload omitted when empty, got %s", raw["raw_payload"])
+	}
+}
+
+// TestRawPayloadDoesNotBumpSchema 确认新增 RawPayload 不改变契约版本（增量 optional，
+// 不 bump：consumer 严格相等校验，bump 会让在飞 v2 消息全进 DLQ）。
+func TestRawPayloadDoesNotBumpSchema(t *testing.T) {
+	if SchemaVersion != 2 {
+		t.Fatalf("RawPayload is an additive optional field and must NOT bump SchemaVersion; got %d want 2", SchemaVersion)
+	}
+}
+
 // TestRawExcludedNullContent 确认 raw_excluded 时 content 序列化为 JSON null。
 func TestRawExcludedNullContent(t *testing.T) {
 	in := Message{


### PR DESCRIPTION
## What

Add an optional `RawPayload json.RawMessage` field to `searchmsg.Message`, the Kafka body contract shared across the search-indexer pipeline.

This enables the CDC-style write model for octo-search-indexer: the producer degrades to shipping the **raw payload verbatim** + metadata, and the es-indexer consumer does the full payload projection + visibility fail-closed parsing from this field (instead of the producer pre-parsing only text).

## Why `json.RawMessage` (not `[]byte`)

`[]byte` is base64-encoded by Go's JSON marshaller (~33% bloat), which would push large payloads past the Kafka 1 MiB write-side hard limit. `json.RawMessage` inlines the original JSON bytes (zero bloat) and stays human-readable for Kafka-side triage.

## Compatibility

- **Additive optional** (`omitempty`). Does **NOT** bump `SchemaVersion` — the consumer does a strict-equality version check, so a bump would dead-letter every in-flight v2 message.
- Encrypted messages keep `RawPayload=nil` (ciphertext never leaves); consumers take the encrypted branch via `len(RawPayload)==0 && RawExcluded`.
- In-flight legacy v2 messages have no `raw_payload` field; consumers fall back to the existing `Content`/`ContentType` path.

## Tests

`go test ./contract/searchmsg/...` — added round-trip, omitempty, and no-schema-bump assertions for the new field.

This is the first PR of a two-repo merge chain; the dependent octo-search-indexer PR pins this version once merged.



Closes #84
