### PR TITLE
ci(osv-scanner): stop exporting scan JSON as job outputs (>1MB fix)

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -17,7 +17,14 @@ permissions:
 jobs:
   scan-scheduled:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
+    # Pinned to the commit that adds `export-results` (default false) so the
+    # reusable workflow no longer cats the full scan JSON into job outputs.
+    # Without it the "Export results" step can exceed GitHub's 1,048,576-byte
+    # job-output limit and fail the run even when the scan itself is green.
+    # This commit only adds the gating flag; the inner osv-scanner/reporter
+    # actions stay pinned to v2.3.8. Revert to a release tag once one ships
+    # that includes this fix (post-v2.3.8).
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@3a7550f43ba5b58905a821ce3a0ed24c4858b3f4  # export-results gating, inner actions v2.3.8
     with:
       scan-args: |-
         -r
@@ -31,7 +38,14 @@ jobs:
 
   scan-pr:
     if: github.event_name == 'pull_request'
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
+    # Pinned to the commit that adds `export-results` (default false). The PR
+    # reusable workflow used to cat both old/new scan JSON into job outputs,
+    # which tripped GitHub's 1,048,576-byte job-output limit ("Job outputs
+    # exceed 1,048,576 bytes") and failed scan-pr even though the scan passed.
+    # We don't consume those outputs, so leaving export-results at its default
+    # (false) removes the oversized output. Inner actions remain v2.3.8.
+    # Revert to a release tag once one ships that includes this fix (post-v2.3.8).
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@3a7550f43ba5b58905a821ce3a0ed24c4858b3f4  # export-results gating, inner actions v2.3.8
     with:
       scan-args: |-
         -r


### PR DESCRIPTION
## Problem

\`scan-pr / osv-scan\` was failing with the annotation **"Job outputs exceed 1,048,576 bytes"**, which also kept its downstream \`notify / notify\` red. The osv scan steps themselves were all green — the failure came from the reusable workflow's **"Export results"** step.

The osv-scanner reusable workflows pinned at v2.3.8 (\`osv-scanner-reusable.yml\` and \`osv-scanner-reusable-pr.yml\`) unconditionally \`cat\` the full scan JSON into \`GITHUB_OUTPUT\` and expose it as job outputs (\`old-results\` / \`new-results\`). On this repo the recursive scan result exceeds GitHub's 1,048,576-byte job-output limit, so the job fails even when the scan passes. We never consume those outputs.

## Fix

Re-pin both reusable workflows to upstream commit [\`3a7550f\`](https://github.com/google/osv-scanner-action/commit/3a7550f43ba5b58905a821ce3a0ed24c4858b3f4) ("feat: gate reusable workflow outputs with a flag"), which gates the "Export results" step behind a new \`export-results\` input that **defaults to false**. This is the minimal upstream fix and not yet in any release tag (lands post-v2.3.8).

- The inner \`osv-scanner-action\` / \`osv-reporter-action\` stay pinned to the **same v2.3.8 SHA** — only the export gating changes.
- We don't read the job outputs anywhere, so leaving \`export-results\` at its default removes the oversized output.
- Revert to a release tag once one ships that includes this fix.

## Verification

This PR touches \`.github/workflows/osv-scanner.yml\`, so opening it re-runs \`scan-pr / osv-scan\` and \`notify\` directly — the PR is its own verification. Expecting osv-scan + notify + dependency-review to go green.

Closes #88

(multica: YUJ-5425)