### PR TITLE
feat: add MySQL/Redis client-seam latency observers

### DIFF
--- a/pkg/db/instrument.go
+++ b/pkg/db/instrument.go
@@ -37,7 +37,12 @@ func SetDBObserver(o DBObserver) {
 }
 
 // reportDB 把一次调用转发给已注入的 observer；未注入时为 no-op。
+//
+// 在接缝处兜住下游 observer 的 panic:observer 跑在每条 DB 调用的热路径上,一个
+// nil-deref 不该顺着所有查询炸上来,最多丢掉这一条埋点样本。godoc 已要求实现方
+// "不 panic",这里再加一道防线而非纯靠信任。
 func reportDB(op string, dur time.Duration, err error) {
+	defer func() { _ = recover() }()
 	if p := dbObserver.Load(); p != nil {
 		(*p)(op, dur, err)
 	}

--- a/pkg/db/instrument.go
+++ b/pkg/db/instrument.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"context"
+	"database/sql/driver"
+	"sync/atomic"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// DBObserver 接收一次 MySQL 客户端调用的耗时。op 是低基数枚举：
+//
+//   - "connect"：建立一条新连接（驱动握手 + 鉴权），由 instrumentedConnector 上报，
+//     用于把「建连握手」从「取连接等待 / 执行」中隔离出来；
+//   - "query"：一条 dbr 查询（select / exec）的执行耗时，由 metricEventReceiver 上报。
+//
+// dur 为本次调用耗时；err 为调用结果（nil 表示成功）。实现方应保证轻量且不 panic，
+// 它在每条 DB 调用的热路径上同步执行。
+//
+// octo-lib 不依赖 Prometheus —— 仅暴露这个回调，由 octo-server 在启动时用
+// SetDBObserver 注入真实实现（接 #442 的 DependencyMetrics，label dependency=mysql）。
+type DBObserver func(op string, dur time.Duration, err error)
+
+// dbObserver 持有进程级 observer。用 atomic.Pointer：启动时 SetDBObserver 设置一次，
+// 业务热路径只读；未注入（指标关闭 / 单测）时 reportDB 为安全 no-op，绝不 panic。
+var dbObserver atomic.Pointer[DBObserver]
+
+// SetDBObserver 注入进程级 DB observer。传 nil 可清除（恢复 no-op）。
+// 通常在 main 启动早期调用一次。
+func SetDBObserver(o DBObserver) {
+	if o == nil {
+		dbObserver.Store(nil)
+		return
+	}
+	dbObserver.Store(&o)
+}
+
+// reportDB 把一次调用转发给已注入的 observer；未注入时为 no-op。
+func reportDB(op string, dur time.Duration, err error) {
+	if p := dbObserver.Load(); p != nil {
+		(*p)(op, dur, err)
+	}
+}
+
+// metricEventReceiver 实现 dbr.EventReceiver，把每条查询的执行耗时经
+// Timing/TimingKv 上报为 op="query"。其余事件（Event*/EventErr*）由内嵌的
+// NullEventReceiver 兜底为 no-op。
+//
+// 为何只在 Timing 上报、不在 EventErr 上报：dbr 的 select/exec 用 defer 触发
+// TimingKv，因此「失败的查询」会同时触发 TimingKv（带真实耗时）和 EventErrKv。
+// 若在两处都上报，一条失败查询会产生两条样本（一条 ok + 一条 error），既重复计数
+// 又把失败误标成 ok。故只取 Timing 这个「每条查询必触发一次」的信号，统一记为耗时
+// 样本。代价：本指标不区分查询成功/失败（错误另由 dbr 自身日志与 connect 段体现），
+// 与发版说明里的 caveat 一致。
+type metricEventReceiver struct {
+	*dbr.NullEventReceiver
+}
+
+// Timing 接收一条查询的执行耗时（纳秒），上报为 op="query"。
+func (metricEventReceiver) Timing(eventName string, nanoseconds int64) {
+	reportDB("query", time.Duration(nanoseconds), nil)
+}
+
+// TimingKv 接收一条查询的执行耗时（纳秒）及附带 kv，上报为 op="query"。
+// kv（含 sql 文本）刻意不进 label，避免基数爆炸。
+func (metricEventReceiver) TimingKv(eventName string, nanoseconds int64, kvs map[string]string) {
+	reportDB("query", time.Duration(nanoseconds), nil)
+}
+
+// instrumentedConnector 包一层 driver.Connector，对每次建连（Connect）计时并上报
+// op="connect"，从而把建连握手从执行耗时中隔离出来。Driver() 由内嵌 Connector 提升。
+type instrumentedConnector struct {
+	driver.Connector
+}
+
+// Connect 计时底层建连并上报。失败的建连同样带耗时（握手/鉴权失败也是真实耗时），
+// 故 connect 段保留完整的 ok/error 状态。
+func (c instrumentedConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	start := time.Now()
+	conn, err := c.Connector.Connect(ctx)
+	reportDB("connect", time.Since(start), err)
+	return conn, err
+}

--- a/pkg/db/instrument.go
+++ b/pkg/db/instrument.go
@@ -5,21 +5,27 @@ import (
 	"database/sql/driver"
 	"sync/atomic"
 	"time"
-
-	"github.com/gocraft/dbr/v2"
 )
 
 // DBObserver 接收一次 MySQL 客户端调用的耗时。op 是低基数枚举：
 //
-//   - "connect"：建立一条新连接（驱动握手 + 鉴权），由 instrumentedConnector 上报，
-//     用于把「建连握手」从「取连接等待 / 执行」中隔离出来；
-//   - "query"：一条 dbr 查询（select / exec）的执行耗时，由 metricEventReceiver 上报。
+//   - "connect"：建立一条新连接（驱动握手 + 鉴权），由 instrumentedConnector 上报；
+//   - "query"：拿到连接之后一条语句的纯执行耗时（ExecContext / QueryContext），由
+//     instrumentedConn 上报。
 //
-// dur 为本次调用耗时；err 为调用结果（nil 表示成功）。实现方应保证轻量且不 panic，
-// 它在每条 DB 调用的热路径上同步执行。
+// 关键：query 在连接已从池中取得之后才开始计时,因此「建连握手 / 取连接等待 / 执行」
+// 三段不重叠 —— connect=握手,取连接等待看连接池的 WaitDuration,query=执行。
+//
+// dur 为本次调用耗时；err 为调用结果（nil 表示成功）。connect 与 query 都携带真实
+// err（query 走驱动层,拿得到执行错误）。实现方应保证轻量且不 panic，它在每条 DB
+// 调用的热路径上同步执行。
 //
 // octo-lib 不依赖 Prometheus —— 仅暴露这个回调，由 octo-server 在启动时用
 // SetDBObserver 注入真实实现（接 #442 的 DependencyMetrics，label dependency=mysql）。
+//
+// 覆盖范围：dbr 通过插值把参数内联进 SQL 后直接走 ExecContext/QueryContext,故其全部
+// 查询都被计时。显式预编译语句（driver.Stmt）的执行走 Stmt 而非 conn,不在此覆盖
+// （dbr 不预编译）。
 type DBObserver func(op string, dur time.Duration, err error)
 
 // dbObserver 持有进程级 observer。用 atomic.Pointer：启动时 SetDBObserver 设置一次，
@@ -48,42 +54,120 @@ func reportDB(op string, dur time.Duration, err error) {
 	}
 }
 
-// metricEventReceiver 实现 dbr.EventReceiver，把每条查询的执行耗时经
-// Timing/TimingKv 上报为 op="query"。其余事件（Event*/EventErr*）由内嵌的
-// NullEventReceiver 兜底为 no-op。
-//
-// 为何只在 Timing 上报、不在 EventErr 上报：dbr 的 select/exec 用 defer 触发
-// TimingKv，因此「失败的查询」会同时触发 TimingKv（带真实耗时）和 EventErrKv。
-// 若在两处都上报，一条失败查询会产生两条样本（一条 ok + 一条 error），既重复计数
-// 又把失败误标成 ok。故只取 Timing 这个「每条查询必触发一次」的信号，统一记为耗时
-// 样本。代价：本指标不区分查询成功/失败（错误另由 dbr 自身日志与 connect 段体现），
-// 与发版说明里的 caveat 一致。
-type metricEventReceiver struct {
-	*dbr.NullEventReceiver
-}
-
-// Timing 接收一条查询的执行耗时（纳秒），上报为 op="query"。
-func (metricEventReceiver) Timing(eventName string, nanoseconds int64) {
-	reportDB("query", time.Duration(nanoseconds), nil)
-}
-
-// TimingKv 接收一条查询的执行耗时（纳秒）及附带 kv，上报为 op="query"。
-// kv（含 sql 文本）刻意不进 label，避免基数爆炸。
-func (metricEventReceiver) TimingKv(eventName string, nanoseconds int64, kvs map[string]string) {
-	reportDB("query", time.Duration(nanoseconds), nil)
-}
-
-// instrumentedConnector 包一层 driver.Connector，对每次建连（Connect）计时并上报
-// op="connect"，从而把建连握手从执行耗时中隔离出来。Driver() 由内嵌 Connector 提升。
+// instrumentedConnector 包一层 driver.Connector：对每次建连（Connect）计时并上报
+// op="connect"，并把返回的连接包成 instrumentedConn 以便对执行计时。Driver() 由内嵌
+// Connector 提升。
 type instrumentedConnector struct {
 	driver.Connector
 }
 
 // Connect 计时底层建连并上报。失败的建连同样带耗时（握手/鉴权失败也是真实耗时），
-// 故 connect 段保留完整的 ok/error 状态。
+// 故 connect 段保留完整的 ok/error 状态。成功则把连接包成 instrumentedConn。
 func (c instrumentedConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	start := time.Now()
 	conn, err := c.Connector.Connect(ctx)
 	reportDB("connect", time.Since(start), err)
-	return conn, err
+	if err != nil {
+		return nil, err
+	}
+	return instrumentedConn{conn}, nil
+}
+
+// instrumentedConn 包一层 driver.Conn，对 ExecContext/QueryContext 计时并上报
+// op="query"。连接此时已从池中取得,测的是纯执行耗时(不含取连接等待/握手)。
+//
+// database/sql 通过类型断言探测 driver.Conn 的可选接口。用接口类型内嵌 driver.Conn
+// 只会提升 Prepare/Close/Begin,其余可选接口（ExecerContext / QueryerContext /
+// ConnPrepareContext / ConnBeginTx / Pinger / NamedValueChecker / SessionResetter /
+// Validator）会被「藏掉」,导致 database/sql 退化(丢预编译上下文 / 连接复用 reset /
+// 参数检查 / 坏连接探活等)。因此这里把 go-sql-driver/mysql 实现的全部可选接口逐一
+// 重新暴露并委托;只有 Exec/Query 两条加计时。断言失败时给出与「未实现」等价的安全
+// 回退(对 mysql 而言是 dead path,纯防御)。
+type instrumentedConn struct {
+	driver.Conn
+}
+
+var (
+	_ driver.ExecerContext      = instrumentedConn{}
+	_ driver.QueryerContext     = instrumentedConn{}
+	_ driver.ConnPrepareContext = instrumentedConn{}
+	_ driver.ConnBeginTx        = instrumentedConn{}
+	_ driver.Pinger             = instrumentedConn{}
+	_ driver.NamedValueChecker  = instrumentedConn{}
+	_ driver.SessionResetter    = instrumentedConn{}
+	_ driver.Validator          = instrumentedConn{}
+)
+
+// ExecContext 计执行耗时并上报 op="query"。driver.ErrSkip 表示「请退回 Prepare 路径」,
+// 不是真实执行,不计样本。
+func (c instrumentedConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	ec, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	res, err := ec.ExecContext(ctx, query, args)
+	if err != driver.ErrSkip {
+		reportDB("query", time.Since(start), err)
+	}
+	return res, err
+}
+
+// QueryContext 计执行耗时并上报 op="query"。耗时覆盖到结果集首包返回（执行+首响应）,
+// 不含调用方后续逐行读取。
+func (c instrumentedConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	qc, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	start := time.Now()
+	rows, err := qc.QueryContext(ctx, query, args)
+	if err != driver.ErrSkip {
+		reportDB("query", time.Since(start), err)
+	}
+	return rows, err
+}
+
+// 以下为可选接口的透传委托(不计时),用于在包装后保持底层驱动的完整能力。
+
+func (c instrumentedConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if cpc, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		return cpc.PrepareContext(ctx, query)
+	}
+	return c.Prepare(query)
+}
+
+func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if cbt, ok := c.Conn.(driver.ConnBeginTx); ok {
+		return cbt.BeginTx(ctx, opts)
+	}
+	return c.Conn.Begin() //nolint:staticcheck // 非 ctx 驱动的防御回退;mysql 恒实现 ConnBeginTx
+}
+
+func (c instrumentedConn) Ping(ctx context.Context) error {
+	if p, ok := c.Conn.(driver.Pinger); ok {
+		return p.Ping(ctx)
+	}
+	return nil
+}
+
+func (c instrumentedConn) CheckNamedValue(nv *driver.NamedValue) error {
+	if nvc, ok := c.Conn.(driver.NamedValueChecker); ok {
+		return nvc.CheckNamedValue(nv)
+	}
+	return driver.ErrSkip // 退回 database/sql 默认参数转换
+}
+
+func (c instrumentedConn) ResetSession(ctx context.Context) error {
+	if sr, ok := c.Conn.(driver.SessionResetter); ok {
+		return sr.ResetSession(ctx)
+	}
+	return nil
+}
+
+func (c instrumentedConn) IsValid() bool {
+	if v, ok := c.Conn.(driver.Validator); ok {
+		return v.IsValid()
+	}
+	return true
 }

--- a/pkg/db/instrument_test.go
+++ b/pkg/db/instrument_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 	"time"
-
-	"github.com/gocraft/dbr/v2"
 )
 
 // capturedDB 记录 observer 收到的一次调用。
@@ -30,34 +28,66 @@ func installDBObserver(t *testing.T) *capturedDB {
 	return c
 }
 
-func TestMetricEventReceiverTimingReportsQuery(t *testing.T) {
-	c := installDBObserver(t)
-	r := metricEventReceiver{&dbr.NullEventReceiver{}}
+// stubConn 实现 driver.Conn + ExecerContext/QueryerContext,用于测 instrumentedConn。
+type stubConn struct {
+	execErr  error
+	queryErr error
+}
 
-	r.Timing("dbr.select", int64(5*time.Millisecond))
-	if c.n != 1 || c.op != "query" || c.err != nil || c.dur != 5*time.Millisecond {
-		t.Fatalf("Timing: got op=%q dur=%v err=%v n=%d", c.op, c.dur, c.err, c.n)
+func (stubConn) Prepare(string) (driver.Stmt, error) { return nil, nil }
+func (stubConn) Close() error                        { return nil }
+func (stubConn) Begin() (driver.Tx, error)           { return nil, nil }
+func (c stubConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return nil, c.execErr
+}
+func (c stubConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return nil, c.queryErr
+}
+
+func TestInstrumentedConnReportsQuerySuccess(t *testing.T) {
+	c := installDBObserver(t)
+	ic := instrumentedConn{stubConn{}}
+
+	if _, err := ic.ExecContext(context.Background(), "update x", nil); err != nil {
+		t.Fatalf("ExecContext: %v", err)
+	}
+	if c.n != 1 || c.op != "query" || c.err != nil {
+		t.Fatalf("exec: got op=%q err=%v n=%d", c.op, c.err, c.n)
 	}
 
-	r.TimingKv("dbr.exec", int64(7*time.Millisecond), map[string]string{"sql": "update x"})
-	if c.n != 2 || c.op != "query" || c.err != nil || c.dur != 7*time.Millisecond {
-		t.Fatalf("TimingKv: got op=%q dur=%v err=%v n=%d", c.op, c.dur, c.err, c.n)
+	if _, err := ic.QueryContext(context.Background(), "select 1", nil); err != nil {
+		t.Fatalf("QueryContext: %v", err)
+	}
+	if c.n != 2 || c.op != "query" || c.err != nil {
+		t.Fatalf("query: got op=%q err=%v n=%d", c.op, c.err, c.n)
 	}
 }
 
-// errEvents 断言失败路径只走 Event*（no-op，不上报），不产生 query 样本 ——
-// 印证「失败查询不会在 Timing 之外被二次上报」的设计。
-func TestMetricEventReceiverErrorPathDoesNotReport(t *testing.T) {
+// 驱动层拿得到真实执行错误,故 op="query" 现在携带 error 状态(对比旧 dbr.Timing 路径)。
+func TestInstrumentedConnReportsQueryError(t *testing.T) {
 	c := installDBObserver(t)
-	r := metricEventReceiver{&dbr.NullEventReceiver{}}
+	boom := errors.New("syntax error")
+	ic := instrumentedConn{stubConn{execErr: boom}}
 
-	sentinel := errors.New("boom")
-	if got := r.EventErrKv("dbr.exec.exec", sentinel, nil); got != sentinel {
-		t.Fatalf("EventErrKv should passthrough err, got %v", got)
+	_, err := ic.ExecContext(context.Background(), "bad sql", nil)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err should propagate, got %v", err)
 	}
-	r.Event("dbr.begin")
+	if c.n != 1 || c.op != "query" || !errors.Is(c.err, boom) {
+		t.Fatalf("failed query must report with err: op=%q err=%v n=%d", c.op, c.err, c.n)
+	}
+}
+
+// driver.ErrSkip 是「退回 Prepare 路径」的信号,不是真实执行,不应计样本。
+func TestInstrumentedConnExecErrSkipNotReported(t *testing.T) {
+	c := installDBObserver(t)
+	ic := instrumentedConn{stubConn{execErr: driver.ErrSkip}}
+
+	if _, err := ic.ExecContext(context.Background(), "x", nil); err != driver.ErrSkip {
+		t.Fatalf("ErrSkip should propagate, got %v", err)
+	}
 	if c.n != 0 {
-		t.Fatalf("error/event path must not report, got n=%d", c.n)
+		t.Fatalf("ErrSkip must not be reported as a query sample, got n=%d", c.n)
 	}
 }
 

--- a/pkg/db/instrument_test.go
+++ b/pkg/db/instrument_test.go
@@ -103,6 +103,13 @@ func TestReportDBNoObserverIsNoop(t *testing.T) {
 	reportDB("query", time.Millisecond, nil) // 不得 panic
 }
 
+// 下游 observer panic 必须被接缝兜住,不得顺着 DB 调用炸上来。
+func TestReportDBRecoversFromObserverPanic(t *testing.T) {
+	SetDBObserver(func(string, time.Duration, error) { panic("boom") })
+	t.Cleanup(func() { SetDBObserver(nil) })
+	reportDB("query", time.Millisecond, nil) // 不得 panic
+}
+
 // NewMySQL 不应在构造时建连（sql.OpenDB 是惰性的），故无需真实 DB 即可构造成功。
 func TestNewMySQLConstructsWithoutConnecting(t *testing.T) {
 	sess := NewMySQL("user:pass@tcp(127.0.0.1:3306)/db?parseTime=true", 10, 5, time.Hour)

--- a/pkg/db/instrument_test.go
+++ b/pkg/db/instrument_test.go
@@ -1,0 +1,112 @@
+package db
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// capturedDB 记录 observer 收到的一次调用。
+type capturedDB struct {
+	op  string
+	dur time.Duration
+	err error
+	n   int
+}
+
+// installDBObserver 安装一个记录型 observer 并在测试结束时清除。
+func installDBObserver(t *testing.T) *capturedDB {
+	t.Helper()
+	c := &capturedDB{}
+	SetDBObserver(func(op string, dur time.Duration, err error) {
+		c.op, c.dur, c.err = op, dur, err
+		c.n++
+	})
+	t.Cleanup(func() { SetDBObserver(nil) })
+	return c
+}
+
+func TestMetricEventReceiverTimingReportsQuery(t *testing.T) {
+	c := installDBObserver(t)
+	r := metricEventReceiver{&dbr.NullEventReceiver{}}
+
+	r.Timing("dbr.select", int64(5*time.Millisecond))
+	if c.n != 1 || c.op != "query" || c.err != nil || c.dur != 5*time.Millisecond {
+		t.Fatalf("Timing: got op=%q dur=%v err=%v n=%d", c.op, c.dur, c.err, c.n)
+	}
+
+	r.TimingKv("dbr.exec", int64(7*time.Millisecond), map[string]string{"sql": "update x"})
+	if c.n != 2 || c.op != "query" || c.err != nil || c.dur != 7*time.Millisecond {
+		t.Fatalf("TimingKv: got op=%q dur=%v err=%v n=%d", c.op, c.dur, c.err, c.n)
+	}
+}
+
+// errEvents 断言失败路径只走 Event*（no-op，不上报），不产生 query 样本 ——
+// 印证「失败查询不会在 Timing 之外被二次上报」的设计。
+func TestMetricEventReceiverErrorPathDoesNotReport(t *testing.T) {
+	c := installDBObserver(t)
+	r := metricEventReceiver{&dbr.NullEventReceiver{}}
+
+	sentinel := errors.New("boom")
+	if got := r.EventErrKv("dbr.exec.exec", sentinel, nil); got != sentinel {
+		t.Fatalf("EventErrKv should passthrough err, got %v", got)
+	}
+	r.Event("dbr.begin")
+	if c.n != 0 {
+		t.Fatalf("error/event path must not report, got n=%d", c.n)
+	}
+}
+
+// stubConnector 是一个可控返回的 driver.Connector，用于测 instrumentedConnector。
+type stubConnector struct {
+	conn driver.Conn
+	err  error
+}
+
+func (s stubConnector) Connect(context.Context) (driver.Conn, error) { return s.conn, s.err }
+func (s stubConnector) Driver() driver.Driver                        { return nil }
+
+func TestInstrumentedConnectorReportsConnectSuccess(t *testing.T) {
+	c := installDBObserver(t)
+	ic := instrumentedConnector{Connector: stubConnector{conn: nil, err: nil}}
+
+	_, err := ic.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if c.n != 1 || c.op != "connect" || c.err != nil {
+		t.Fatalf("got op=%q err=%v n=%d", c.op, c.err, c.n)
+	}
+}
+
+func TestInstrumentedConnectorReportsConnectError(t *testing.T) {
+	c := installDBObserver(t)
+	sentinel := errors.New("dial fail")
+	ic := instrumentedConnector{Connector: stubConnector{err: sentinel}}
+
+	_, err := ic.Connect(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err should propagate, got %v", err)
+	}
+	if c.n != 1 || c.op != "connect" || !errors.Is(c.err, sentinel) {
+		t.Fatalf("failed connect must report with err: op=%q err=%v n=%d", c.op, c.err, c.n)
+	}
+}
+
+// 未注入 observer 时上报必须是安全 no-op。
+func TestReportDBNoObserverIsNoop(t *testing.T) {
+	SetDBObserver(nil)
+	reportDB("query", time.Millisecond, nil) // 不得 panic
+}
+
+// NewMySQL 不应在构造时建连（sql.OpenDB 是惰性的），故无需真实 DB 即可构造成功。
+func TestNewMySQLConstructsWithoutConnecting(t *testing.T) {
+	sess := NewMySQL("user:pass@tcp(127.0.0.1:3306)/db?parseTime=true", 10, 5, time.Hour)
+	if sess == nil || sess.Connection == nil || sess.DB == nil {
+		t.Fatal("NewMySQL returned an incomplete session")
+	}
+}

--- a/pkg/db/instrument_test.go
+++ b/pkg/db/instrument_test.go
@@ -129,6 +129,7 @@ func TestInstrumentedConnectorReportsConnectError(t *testing.T) {
 
 // 未注入 observer 时上报必须是安全 no-op。
 func TestReportDBNoObserverIsNoop(t *testing.T) {
+	t.Cleanup(func() { SetDBObserver(nil) })
 	SetDBObserver(nil)
 	reportDB("query", time.Millisecond, nil) // 不得 panic
 }

--- a/pkg/db/mysql.go
+++ b/pkg/db/mysql.go
@@ -19,7 +19,12 @@ import (
 // 不再走 dbr.Open（内部 sql.Open + 默认 driver），而是手动用
 // sql.OpenDB(instrumentedConnector{...}) 打开，并手搭 *dbr.Connection。这样：
 //   - 建连握手经 instrumentedConnector.Connect 计时（op="connect"）；
-//   - 每条查询经 metricEventReceiver 计时（op="query"）。
+//   - 拿到连接之后每条语句的纯执行经 instrumentedConn 计时（op="query"）。
+//
+// 计时落在驱动层(connect 在建连处、query 在连接已取得之后),所以「建连握手 / 取连接
+// 等待 / 执行」三段不重叠;取连接等待由连接池的 WaitDuration 体现。dbr 自身的
+// EventReceiver 不再用于打点(用 NullEventReceiver 兜底,dbr 的 Timing 含取连接等待,
+// 量的不是纯执行)。
 //
 // 池参数（MaxOpenConns/MaxIdleConns/ConnMaxLifetime）与迁移行为保持不变。
 // 注：ConnMaxLifetime 建议设为小于 MySQL 服务端 wait_timeout（默认 28800s），
@@ -38,7 +43,7 @@ func NewMySQL(addr string, maxOpenConns int, maxIdleConns int, connMaxLifetime t
 	conn := &dbr.Connection{
 		DB:            sqlDB,
 		Dialect:       dialect.MySQL,
-		EventReceiver: metricEventReceiver{&dbr.NullEventReceiver{}},
+		EventReceiver: &dbr.NullEventReceiver{},
 	}
 
 	session := conn.NewSession(nil)

--- a/pkg/db/mysql.go
+++ b/pkg/db/mysql.go
@@ -1,27 +1,45 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql" // mysql
+	"github.com/go-sql-driver/mysql"
 	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 	migrate "github.com/rubenv/sql-migrate"
 )
 
 // NewMySQL 创建一个MySQL db，[path]db存储路径 [sqlDir]sql脚本目录
+//
+// 不再走 dbr.Open（内部 sql.Open + 默认 driver），而是手动用
+// sql.OpenDB(instrumentedConnector{...}) 打开，并手搭 *dbr.Connection。这样：
+//   - 建连握手经 instrumentedConnector.Connect 计时（op="connect"）；
+//   - 每条查询经 metricEventReceiver 计时（op="query"）。
+//
+// 池参数（MaxOpenConns/MaxIdleConns/ConnMaxLifetime）与迁移行为保持不变。
+// 注：ConnMaxLifetime 建议设为小于 MySQL 服务端 wait_timeout（默认 28800s），
+// 以免使用到被服务端单方面关闭的陈旧连接。
 func NewMySQL(addr string, maxOpenConns int, maxIdleConns int, connMaxLifetime time.Duration) *dbr.Session {
 
-	conn, err := dbr.Open("mysql", addr, nil)
+	base, err := mysql.MySQLDriver{}.OpenConnector(addr)
 	if err != nil {
 		panic(err)
 	}
-	conn.SetMaxOpenConns(maxOpenConns)
-	conn.SetMaxIdleConns(maxIdleConns)
-	conn.SetConnMaxLifetime(connMaxLifetime) //mysql 默认超时时间为 60*60*8=28800 SetConnMaxLifetime设置为小于数据库超时时间即可
+	sqlDB := sql.OpenDB(instrumentedConnector{Connector: base})
+	sqlDB.SetMaxOpenConns(maxOpenConns)
+	sqlDB.SetMaxIdleConns(maxIdleConns)
+	sqlDB.SetConnMaxLifetime(connMaxLifetime) //mysql 默认超时时间为 60*60*8=28800 SetConnMaxLifetime设置为小于数据库超时时间即可
+
+	conn := &dbr.Connection{
+		DB:            sqlDB,
+		Dialect:       dialect.MySQL,
+		EventReceiver: metricEventReceiver{&dbr.NullEventReceiver{}},
+	}
 
 	session := conn.NewSession(nil)
 

--- a/pkg/redis/instrument.go
+++ b/pkg/redis/instrument.go
@@ -1,0 +1,78 @@
+package redis
+
+import (
+	"sync/atomic"
+	"time"
+
+	rd "github.com/go-redis/redis"
+)
+
+// RedisObserver 接收一次 Redis 命令的耗时。cmd 是命令名（已小写，如 "get"/"set"/
+// "eval"），低基数；dur 为耗时；err 为命令结果（nil 表示成功）。
+//
+// 实现方应保证轻量且不 panic —— 它在每条命令的热路径上同步执行。
+//
+// octo-lib 不依赖 Prometheus —— 仅暴露这个回调，由 octo-server 在启动时用
+// SetRedisObserver 注入真实实现（接 #442 的 DependencyMetrics，label dependency=redis）。
+type RedisObserver func(cmd string, dur time.Duration, err error)
+
+// redisObserver 持有进程级 observer。用 atomic.Pointer：启动时 SetRedisObserver
+// 设置一次，业务热路径只读；未注入时 reportRedis 为安全 no-op，绝不 panic。
+var redisObserver atomic.Pointer[RedisObserver]
+
+// SetRedisObserver 注入进程级 Redis observer。传 nil 可清除（恢复 no-op）。
+// 通常在 main 启动早期调用一次。
+//
+// 注意：observer 是进程级单例。SetRedisObserver 影响之后经 instrumentClient 计时
+// 的所有 client 的上报目标；instrumentClient 自身在 New/NewWithOptions 构造时即已
+// 挂好 hook，与 observer 是否注入无关。
+func SetRedisObserver(o RedisObserver) {
+	if o == nil {
+		redisObserver.Store(nil)
+		return
+	}
+	redisObserver.Store(&o)
+}
+
+// reportRedis 把一次命令转发给已注入的 observer；未注入时为 no-op。
+func reportRedis(cmd string, dur time.Duration, err error) {
+	if p := redisObserver.Load(); p != nil {
+		(*p)(cmd, dur, err)
+	}
+}
+
+// instrumentClient 用 go-redis v6 的 WrapProcess/WrapProcessPipeline 给每条命令计时。
+// go-redis v6 没有 v8 的 AddHook，WrapProcess 是其等价物（包裹 process 函数）。
+//
+//   - 单条命令：op = cmd.Name()；
+//   - pipeline：作为一次往返整体上报 op = "pipeline"（管道内多命令共享一次 RTT，
+//     无法拆分单命令耗时）。
+//
+// redis.Nil（key 不存在 / 无匹配）是正常的「未命中」语义而非故障，归一为非错误，
+// 避免把命中率噪声混进 error 状态。WrapProcess 只观测、不改变返回给调用方的 err。
+func instrumentClient(client *rd.Client) {
+	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
+		return func(cmd rd.Cmder) error {
+			start := time.Now()
+			err := old(cmd)
+			reportRedis(cmd.Name(), time.Since(start), normalizeRedisErr(err))
+			return err
+		}
+	})
+	client.WrapProcessPipeline(func(old func([]rd.Cmder) error) func([]rd.Cmder) error {
+		return func(cmds []rd.Cmder) error {
+			start := time.Now()
+			err := old(cmds)
+			reportRedis("pipeline", time.Since(start), normalizeRedisErr(err))
+			return err
+		}
+	})
+}
+
+// normalizeRedisErr 把 redis.Nil 归一为 nil（未命中不是故障），其余原样返回。
+func normalizeRedisErr(err error) error {
+	if err == rd.Nil {
+		return nil
+	}
+	return err
+}

--- a/pkg/redis/instrument.go
+++ b/pkg/redis/instrument.go
@@ -35,7 +35,11 @@ func SetRedisObserver(o RedisObserver) {
 }
 
 // reportRedis 把一次命令转发给已注入的 observer；未注入时为 no-op。
+//
+// 在接缝处兜住下游 observer 的 panic:observer 跑在每条命令的热路径上,一个
+// nil-deref 不该顺着 Redis 调用炸上来,最多丢掉这一条埋点样本。
 func reportRedis(cmd string, dur time.Duration, err error) {
+	defer func() { _ = recover() }()
 	if p := redisObserver.Load(); p != nil {
 		(*p)(cmd, dur, err)
 	}
@@ -63,7 +67,7 @@ func instrumentClient(client *rd.Client) {
 		return func(cmds []rd.Cmder) error {
 			start := time.Now()
 			err := old(cmds)
-			reportRedis("pipeline", time.Since(start), normalizeRedisErr(err))
+			reportRedis("pipeline", time.Since(start), pipelineErr(cmds, err))
 			return err
 		}
 	})
@@ -75,4 +79,18 @@ func normalizeRedisErr(err error) error {
 		return nil
 	}
 	return err
+}
+
+// pipelineErr 提炼一个 pipeline 批次里「真正的」错误用于打点。go-redis v6 的
+// pipeline 顶层错误是 cmdsFirstErr —— 按顺序取第一条命令的错误,因此一个打头的
+// redis.Nil（例如对不存在 key 的 GET）会把后面命令的真实失败盖住,导致整批被记成
+// 成功。这里扫描各命令,返回第一条非 redis.Nil 的命令错误;若只有 redis.Nil / 无
+// 命令错误,再回落到归一化后的顶层错误。
+func pipelineErr(cmds []rd.Cmder, topErr error) error {
+	for _, cmd := range cmds {
+		if e := cmd.Err(); e != nil && e != rd.Nil {
+			return e
+		}
+	}
+	return normalizeRedisErr(topErr)
 }

--- a/pkg/redis/instrument_test.go
+++ b/pkg/redis/instrument_test.go
@@ -27,6 +27,31 @@ func TestReportRedisNoObserverIsNoop(t *testing.T) {
 	reportRedis("get", time.Millisecond, nil) // 不得 panic
 }
 
+// 下游 observer panic 必须被接缝兜住,不得顺着 Redis 调用炸上来。
+func TestReportRedisRecoversFromObserverPanic(t *testing.T) {
+	SetRedisObserver(func(string, time.Duration, error) { panic("boom") })
+	t.Cleanup(func() { SetRedisObserver(nil) })
+	reportRedis("get", time.Millisecond, nil) // 不得 panic
+}
+
+// pipelineErr 的可单测分支:无命令错误时回落到归一化顶层错误。
+// (「打头 redis.Nil 盖住后续真实错误」分支需要给命令预置错误,而 go-redis v6
+// 未导出 setErr,无法在外部包构造,留给集成路径覆盖。)
+func TestPipelineErrFallsBackToTopErr(t *testing.T) {
+	okCmd := rd.NewStringCmd("get", "k") // Err()==nil
+
+	if got := pipelineErr([]rd.Cmder{okCmd}, nil); got != nil {
+		t.Fatalf("no errors → nil, got %v", got)
+	}
+	if got := pipelineErr([]rd.Cmder{okCmd}, rd.Nil); got != nil {
+		t.Fatalf("top redis.Nil must normalize to nil, got %v", got)
+	}
+	boom := os.ErrClosed
+	if got := pipelineErr([]rd.Cmder{okCmd}, boom); got != boom {
+		t.Fatalf("real top err must pass through, got %v", got)
+	}
+}
+
 func TestSetRedisObserverRoundTrip(t *testing.T) {
 	var (
 		mu  sync.Mutex

--- a/pkg/redis/instrument_test.go
+++ b/pkg/redis/instrument_test.go
@@ -23,6 +23,7 @@ func TestNormalizeRedisErr(t *testing.T) {
 }
 
 func TestReportRedisNoObserverIsNoop(t *testing.T) {
+	t.Cleanup(func() { SetRedisObserver(nil) })
 	SetRedisObserver(nil)
 	reportRedis("get", time.Millisecond, nil) // 不得 panic
 }

--- a/pkg/redis/instrument_test.go
+++ b/pkg/redis/instrument_test.go
@@ -1,0 +1,98 @@
+package redis
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	rd "github.com/go-redis/redis"
+)
+
+func TestNormalizeRedisErr(t *testing.T) {
+	if normalizeRedisErr(rd.Nil) != nil {
+		t.Fatal("redis.Nil should normalize to nil (cache miss is not a failure)")
+	}
+	other := os.ErrClosed
+	if normalizeRedisErr(other) != other {
+		t.Fatal("non-Nil error must pass through unchanged")
+	}
+	if normalizeRedisErr(nil) != nil {
+		t.Fatal("nil must stay nil")
+	}
+}
+
+func TestReportRedisNoObserverIsNoop(t *testing.T) {
+	SetRedisObserver(nil)
+	reportRedis("get", time.Millisecond, nil) // 不得 panic
+}
+
+func TestSetRedisObserverRoundTrip(t *testing.T) {
+	var (
+		mu  sync.Mutex
+		got struct {
+			cmd string
+			dur time.Duration
+			err error
+		}
+	)
+	SetRedisObserver(func(cmd string, dur time.Duration, err error) {
+		mu.Lock()
+		got.cmd, got.dur, got.err = cmd, dur, err
+		mu.Unlock()
+	})
+	t.Cleanup(func() { SetRedisObserver(nil) })
+
+	reportRedis("set", 3*time.Millisecond, nil)
+	mu.Lock()
+	defer mu.Unlock()
+	if got.cmd != "set" || got.dur != 3*time.Millisecond || got.err != nil {
+		t.Fatalf("got cmd=%q dur=%v err=%v", got.cmd, got.dur, got.err)
+	}
+}
+
+// 集成路径：需要真实 Redis。验证 WrapProcess 把命令名/未命中正确灌给 observer。
+func TestInstrumentClientReportsCommands(t *testing.T) {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set, skipping integration test")
+	}
+
+	type sample struct {
+		cmd string
+		err error
+	}
+	var (
+		mu      sync.Mutex
+		samples []sample
+	)
+	SetRedisObserver(func(cmd string, _ time.Duration, err error) {
+		mu.Lock()
+		samples = append(samples, sample{cmd, err})
+		mu.Unlock()
+	})
+	t.Cleanup(func() { SetRedisObserver(nil) })
+
+	conn := New(addr, os.Getenv("REDIS_PASSWORD"))
+	defer func() { _ = conn.Close() }()
+
+	// GET on a missing key => command name "get", redis.Nil normalized to nil err.
+	if _, err := conn.GetString("test:instrument:missing"); err != nil {
+		t.Fatalf("GetString: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var sawGet bool
+	for _, s := range samples {
+		if s.cmd == "get" {
+			sawGet = true
+			if s.err != nil {
+				t.Fatalf("cache miss must be reported as non-error, got %v", s.err)
+			}
+		}
+	}
+	if !sawGet {
+		t.Fatalf("expected a 'get' sample, got %+v", samples)
+	}
+}

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -27,6 +27,7 @@ func New(addr string, password string) *Conn {
 		MaxRetries: 3, // 失败重试次数
 		Password:   password,
 	})
+	instrumentClient(c.client)
 	return c
 }
 
@@ -44,7 +45,9 @@ func NewWithOptions(opts *rd.Options) *Conn {
 	if local.MaxRetries == 0 {
 		local.MaxRetries = 3
 	}
-	return &Conn{client: rd.NewClient(&local)}
+	client := rd.NewClient(&local)
+	instrumentClient(client)
+	return &Conn{client: client}
 }
 
 // Options returns the underlying go-redis client options. Intended for tests


### PR DESCRIPTION
## What

Adds no-op-by-default **observer seams** at the MySQL and Redis client-construction sites so a downstream consumer (octo-server `#442` `DependencyMetrics`) can record dependency-call latency — **without octo-lib taking a Prometheus dependency**. octo-lib only exposes callbacks; octo-server injects the real implementations at startup.

This gives a clean three-way split of the request tail: **connect handshake** (`op="connect"`) vs **pool-wait** (existing pool `WaitDuration`) vs **execute** (`op="query"`), each measured at a non-overlapping seam.

## Changes

- **`pkg/db/instrument.go`** (new) — `DBObserver` + `SetDBObserver` (`atomic.Pointer`, safe no-op when unset). `instrumentedConnector` wraps `driver.Connector`: times `Connect` as `op="connect"`, and wraps the returned `driver.Conn` in `instrumentedConn`, which times `ExecContext`/`QueryContext` as `op="query"`. Because the timing sits **below** pool acquisition (the conn is already in hand), `op="query"` is pure execute latency — no pool-wait, no cold-pool connect double-count. Driver-level returns the real error, so `op="query"` carries ok/error status.
- **`pkg/db/mysql.go`** — `NewMySQL` opens via `sql.OpenDB(instrumentedConnector{mysql.MySQLDriver{}.OpenConnector(addr)})` and hand-builds `*dbr.Connection` with a plain `NullEventReceiver` (query timing no longer comes from dbr). Pool params and migration behavior unchanged; the `"mysql"` driver stays registered.
- **`pkg/redis/instrument.go`** (new) — `RedisObserver` + `SetRedisObserver`; `instrumentClient` uses go-redis **v6** `WrapProcess`/`WrapProcessPipeline` to time each command; `redis.Nil` normalized to non-error; `pipelineErr` reports the first non-`redis.Nil` command error so a leading cache-miss can't mask a later failure.
- **`pkg/redis/redis.go`** — `New`/`NewWithOptions` install the hook.
- Both seams wrap the observer dispatch in `defer/recover` so a panicking downstream observer is contained to one dropped sample.
- Tests cover connector/conn/observer plumbing (success, error, `ErrSkip`, panic-isolation, pipeline fallback) without a live backend; the Redis command path is exercised behind `REDIS_ADDR`.

## Design notes

- **`op="query"` is execute-only, by construction.** dbr's own `Timing` starts before `database/sql` acquires a connection, so it would fold in pool-wait (and double-count connect on a cold pool). Timing at the `driver.Conn` seam avoids that — the connection is already acquired when `ExecContext`/`QueryContext` runs. (Resolves the round-1 blocker.)
- **Optional-interface preservation.** Wrapping `driver.Conn` would otherwise hide the optional interfaces `database/sql` probes for. `instrumentedConn` re-exposes every one go-sql-driver/mysql implements (`ExecerContext`, `QueryerContext`, `ConnPrepareContext`, `ConnBeginTx`, `Pinger`, `NamedValueChecker`, `SessionResetter`, `Validator`), delegating all but the two timed methods.
- **Callback signature** is `(op/cmd string, dur time.Duration, err error)` — the octo-server adapter feeds `dur` straight into `DependencyMetrics` (same metric family, `dependency=mysql/redis` label values, no new family).

## Coverage caveat

dbr interpolates args into the SQL and calls `Exec`/`QueryContext` directly (no prepared statement), so **all dbr traffic is timed**. Execs issued through an explicit `driver.Stmt` bypass the conn-level hook; dbr does not use that path.

## Follow-ups (tracked in #96)

- blocking Redis commands (`BLPop`/`BRPoplpush`) time the block-wait as latency
- `NewSqlite` not yet instrumented
- octo-server: inject `SetDBObserver`/`SetRedisObserver` → `metrics.ObserveDB/ObserveRedisCmd` (done on the octo-server branch, pending this tag)

~~`op="query"` carries no error status~~ — resolved by the driver-level move.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)