### PR TITLE
feat(config): add Disband field to ChannelInfoCreateReq

### DIFF
--- a/config/msg.go
+++ b/config/msg.go
@@ -1035,6 +1035,7 @@ type ChannelInfoCreateReq struct {
 	ChannelType uint8  `json:"channel_type"` // 频道类型
 	Ban         int    `json:"ban"`          // 是否封禁
 	Large       int    `json:"large"`        // 是否大群
+	Disband     int    `json:"disband"`      // 是否解散
 }
 
 // ChannelReq ChannelReq


### PR DESCRIPTION
## Summary

Add `Disband int` field to `ChannelInfoCreateReq` in `config/msg.go`, following the existing `Ban`/`Large` int-as-bool convention.

When set to `1`, this signals to WuKongIM (via `POST /channel/info`) that a group channel has been disbanded, so message sends are rejected at the IM layer.

## Changes

- `config/msg.go`: Added `Disband int \`json:"disband"\`` field to `ChannelInfoCreateReq` struct

## Related

- Closes #95
- octo-server: Mininglamp-OSS/octo-server#463 (sets `Disband=1`)
- octo-web: Mininglamp-OSS/octo-web#447 (reads disband status)

## Verification

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass