### PR TITLE
feat(redis): export Instrument for raw rd.Client observability

### DIFF
--- a/pkg/redis/instrument.go
+++ b/pkg/redis/instrument.go
@@ -23,9 +23,9 @@ var redisObserver atomic.Pointer[RedisObserver]
 // SetRedisObserver 注入进程级 Redis observer。传 nil 可清除（恢复 no-op）。
 // 通常在 main 启动早期调用一次。
 //
-// 注意：observer 是进程级单例。SetRedisObserver 影响之后经 instrumentClient 计时
-// 的所有 client 的上报目标；instrumentClient 自身在 New/NewWithOptions 构造时即已
-// 挂好 hook，与 observer 是否注入无关。
+// 注意：observer 是进程级单例。SetRedisObserver 影响之后经 Instrument 计时的所有
+// client 的上报目标；Instrument 自身在 New/NewWithOptions 构造时（或裸 client 手动
+// 调用时）即已挂好 hook，与 observer 是否注入无关。
 func SetRedisObserver(o RedisObserver) {
 	if o == nil {
 		redisObserver.Store(nil)
@@ -45,16 +45,25 @@ func reportRedis(cmd string, dur time.Duration, err error) {
 	}
 }
 
-// instrumentClient 用 go-redis v6 的 WrapProcess/WrapProcessPipeline 给每条命令计时。
-// go-redis v6 没有 v8 的 AddHook，WrapProcess 是其等价物（包裹 process 函数）。
+// Instrument 给一个 go-redis v6 的 *rd.Client 挂上每条命令的计时 hook,使其命令也灌入
+// 已注册的 RedisObserver —— 与经 New/NewWithOptions 构造的客户端完全一致。
 //
+// 用途:为**直接用 rd.NewClient 构造的裸客户端**补插桩 —— 它们往往需要 Eval/Script/
+// SetNX 等 pkg/redis 的 Conn 包装未暴露的原语(如限流令牌桶、OIDC 锁、health 探针),
+// 因而绕过了 New/NewWithOptions 的自动插桩。调用方在构造后调一次本函数即可纳入
+// dependency=redis 指标。
+//
+// 注意:New/NewWithOptions 已经调过 Instrument,**不要**对 Conn 构造出来的 client 再调;
+// hook 会在重复调用时层叠(导致重复计数)。故每个 client 只在构造后、共享前调用一次。
+//
+// 计时细节:
 //   - 单条命令：op = cmd.Name()；
 //   - pipeline：作为一次往返整体上报 op = "pipeline"（管道内多命令共享一次 RTT，
 //     无法拆分单命令耗时）。
 //
 // redis.Nil（key 不存在 / 无匹配）是正常的「未命中」语义而非故障，归一为非错误，
 // 避免把命中率噪声混进 error 状态。WrapProcess 只观测、不改变返回给调用方的 err。
-func instrumentClient(client *rd.Client) {
+func Instrument(client *rd.Client) {
 	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
 		return func(cmd rd.Cmder) error {
 			start := time.Now()

--- a/pkg/redis/instrument.go
+++ b/pkg/redis/instrument.go
@@ -107,14 +107,16 @@ func Instrument(client *rd.Client) {
 	if client == nil {
 		return
 	}
+	// 全程持锁:把 WrapProcess 的安装也纳入临界区。否则并发 Instrument(同一 client)时,
+	// 第二个 goroutine 可能在第一个尚未装完 hook 时就看到「已登记」而返回,其调用方随即
+	// 发命令 —— 与 go-redis v6 未加锁的 WrapProcess 赋值并发即数据竞争。WrapProcess 只是
+	// 字段赋值、且仅启动期调用,持锁开销可忽略。
 	instrumentedMu.Lock()
+	defer instrumentedMu.Unlock()
 	if _, ok := instrumented[client]; ok {
-		instrumentedMu.Unlock()
 		return
 	}
 	instrumented[client] = struct{}{}
-	instrumentedMu.Unlock()
-
 	wrapClient(client)
 }
 

--- a/pkg/redis/instrument.go
+++ b/pkg/redis/instrument.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,6 +46,18 @@ func reportRedis(cmd string, dur time.Duration, err error) {
 	}
 }
 
+// instrumented 标记已挂过 hook 的 client,使 Instrument 幂等:重复调用是 no-op。
+// go-redis v6 的 WrapProcess 每调一次就在上一层外再包一层,没有这道 guard,对同一
+// client 调两次(或对 New/NewWithOptions 构造的 client 再手动调一次)会让每条命令
+// 重复计数 2×,且无运行期信号 —— ~15 个裸 client 调用方场景下极易误触。
+//
+// 代价:map 持有 client 指针,会钉住已插桩的 client 不被 GC。本函数面向「长生命周期」
+// 客户端(启动期单例),不要在热循环里对临时 client 反复调用。
+var (
+	instrumentedMu sync.Mutex
+	instrumented   = map[*rd.Client]struct{}{}
+)
+
 // Instrument 给一个 go-redis v6 的 *rd.Client 挂上每条命令的计时 hook,使其命令也灌入
 // 已注册的 RedisObserver —— 与经 New/NewWithOptions 构造的客户端完全一致。
 //
@@ -53,8 +66,8 @@ func reportRedis(cmd string, dur time.Duration, err error) {
 // 因而绕过了 New/NewWithOptions 的自动插桩。调用方在构造后调一次本函数即可纳入
 // dependency=redis 指标。
 //
-// 注意:New/NewWithOptions 已经调过 Instrument,**不要**对 Conn 构造出来的 client 再调;
-// hook 会在重复调用时层叠(导致重复计数)。故每个 client 只在构造后、共享前调用一次。
+// 幂等且 nil-safe:client 为 nil 时直接返回;对同一 client 重复调用(或对
+// New/NewWithOptions 已自动插桩的 client 再调)是 no-op,不会层叠 hook、不会重复计数。
 //
 // 计时细节:
 //   - 单条命令：op = cmd.Name()；
@@ -64,6 +77,17 @@ func reportRedis(cmd string, dur time.Duration, err error) {
 // redis.Nil（key 不存在 / 无匹配）是正常的「未命中」语义而非故障，归一为非错误，
 // 避免把命中率噪声混进 error 状态。WrapProcess 只观测、不改变返回给调用方的 err。
 func Instrument(client *rd.Client) {
+	if client == nil {
+		return
+	}
+	instrumentedMu.Lock()
+	if _, ok := instrumented[client]; ok {
+		instrumentedMu.Unlock()
+		return
+	}
+	instrumented[client] = struct{}{}
+	instrumentedMu.Unlock()
+
 	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
 		return func(cmd rd.Cmder) error {
 			start := time.Now()

--- a/pkg/redis/instrument.go
+++ b/pkg/redis/instrument.go
@@ -89,8 +89,10 @@ func wrapClient(client *rd.Client) {
 // 因而绕过了 New/NewWithOptions 的自动插桩。调用方在构造后调一次本函数即可纳入
 // dependency=redis 指标。
 //
-// 时机:必须在 client 被共享 / 发起命令**之前**调用。go-redis v6 的 WrapProcess 赋值
-// 未加锁,与在途命令并发会 race。
+// 时机:必须在 client 被共享 / 发起命令 / 被 WithContext 克隆**之前**调用。go-redis v6
+// 的 WrapProcess 赋值未加锁,与在途命令并发会 race;且 client.WithContext(ctx) 返回的是
+// 克隆,克隆时即固化当时的 process —— 先克隆、后对原 client 调 Instrument,克隆不会继承
+// 本 hook。需要被观测的克隆,应对其本身调用 Instrument,或在克隆前就插桩好原 client。
 //
 // 幂等且 nil-safe:client 为 nil 时直接返回;对同一 client 重复调用是 no-op,不会层叠
 // hook、不会重复计数。注意它会在内部表里持有该 client 的引用(见 instrumented),故面向

--- a/pkg/redis/instrument.go
+++ b/pkg/redis/instrument.go
@@ -46,17 +46,40 @@ func reportRedis(cmd string, dur time.Duration, err error) {
 	}
 }
 
-// instrumented 标记已挂过 hook 的 client,使 Instrument 幂等:重复调用是 no-op。
-// go-redis v6 的 WrapProcess 每调一次就在上一层外再包一层,没有这道 guard,对同一
-// client 调两次(或对 New/NewWithOptions 构造的 client 再手动调一次)会让每条命令
-// 重复计数 2×,且无运行期信号 —— ~15 个裸 client 调用方场景下极易误触。
+// instrumented 标记已经过 Instrument(公开入口)挂过 hook 的 client,使其幂等:
+// 重复调用是 no-op。go-redis v6 的 WrapProcess 每调一次就在上一层外再包一层,没有
+// 这道 guard,对同一 client 调两次会让每条命令重复计数 2×,且无运行期信号 —— ~15 个
+// 裸 client 调用方场景下极易误触。
 //
-// 代价:map 持有 client 指针,会钉住已插桩的 client 不被 GC。本函数面向「长生命周期」
-// 客户端(启动期单例),不要在热循环里对临时 client 反复调用。
+// 仅公开的 Instrument 登记此表;New/NewWithOptions 走内部 wrapClient,不登记 —— 它们
+// 对刚构造、必然只插一次的 client 操作,无重复风险,也就不必把(可能短生命周期的)
+// New 构造 client 钉在表里不被 GC。所以本表只持有调用方显式传入的长生命周期裸 client。
 var (
 	instrumentedMu sync.Mutex
 	instrumented   = map[*rd.Client]struct{}{}
 )
+
+// wrapClient 把每条命令的计时 hook 挂到 client 上(WrapProcess/WrapProcessPipeline)。
+// 这是内部低层实现,不做 nil / 幂等 guard —— 供 New/NewWithOptions 对自家刚构造的
+// client 调用。公开的 Instrument 在其之上叠加 nil + 幂等 guard。
+func wrapClient(client *rd.Client) {
+	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
+		return func(cmd rd.Cmder) error {
+			start := time.Now()
+			err := old(cmd)
+			reportRedis(cmd.Name(), time.Since(start), normalizeRedisErr(err))
+			return err
+		}
+	})
+	client.WrapProcessPipeline(func(old func([]rd.Cmder) error) func([]rd.Cmder) error {
+		return func(cmds []rd.Cmder) error {
+			start := time.Now()
+			err := old(cmds)
+			reportRedis("pipeline", time.Since(start), pipelineErr(cmds, err))
+			return err
+		}
+	})
+}
 
 // Instrument 给一个 go-redis v6 的 *rd.Client 挂上每条命令的计时 hook,使其命令也灌入
 // 已注册的 RedisObserver —— 与经 New/NewWithOptions 构造的客户端完全一致。
@@ -66,8 +89,12 @@ var (
 // 因而绕过了 New/NewWithOptions 的自动插桩。调用方在构造后调一次本函数即可纳入
 // dependency=redis 指标。
 //
-// 幂等且 nil-safe:client 为 nil 时直接返回;对同一 client 重复调用(或对
-// New/NewWithOptions 已自动插桩的 client 再调)是 no-op,不会层叠 hook、不会重复计数。
+// 时机:必须在 client 被共享 / 发起命令**之前**调用。go-redis v6 的 WrapProcess 赋值
+// 未加锁,与在途命令并发会 race。
+//
+// 幂等且 nil-safe:client 为 nil 时直接返回;对同一 client 重复调用是 no-op,不会层叠
+// hook、不会重复计数。注意它会在内部表里持有该 client 的引用(见 instrumented),故面向
+// 长生命周期客户端(启动期单例),不要在热循环里对临时 client 反复调用。
 //
 // 计时细节:
 //   - 单条命令：op = cmd.Name()；
@@ -88,22 +115,7 @@ func Instrument(client *rd.Client) {
 	instrumented[client] = struct{}{}
 	instrumentedMu.Unlock()
 
-	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
-		return func(cmd rd.Cmder) error {
-			start := time.Now()
-			err := old(cmd)
-			reportRedis(cmd.Name(), time.Since(start), normalizeRedisErr(err))
-			return err
-		}
-	})
-	client.WrapProcessPipeline(func(old func([]rd.Cmder) error) func([]rd.Cmder) error {
-		return func(cmds []rd.Cmder) error {
-			start := time.Now()
-			err := old(cmds)
-			reportRedis("pipeline", time.Since(start), pipelineErr(cmds, err))
-			return err
-		}
-	})
+	wrapClient(client)
 }
 
 // normalizeRedisErr 把 redis.Nil 归一为 nil（未命中不是故障），其余原样返回。

--- a/pkg/redis/instrument_test.go
+++ b/pkg/redis/instrument_test.go
@@ -167,6 +167,22 @@ func TestNewClientInstrumentedReportsCommands(t *testing.T) {
 	}
 }
 
+// New/NewWithOptions 走内部 wrapClient,不应把自家 client 登记进全局幂等表 —— 否则
+// 短生命周期的 New() client 会被钉住不回收(Jerry-Xin review)。非集成,CI 可跑。
+func TestNewDoesNotRetainInGuardMap(t *testing.T) {
+	count := func() int {
+		instrumentedMu.Lock()
+		defer instrumentedMu.Unlock()
+		return len(instrumented)
+	}
+	before := count()
+	conn := NewWithOptions(&rd.Options{Addr: "127.0.0.1:1"}) // 惰性,不会真正连接
+	defer func() { _ = conn.Close() }()
+	if after := count(); after != before {
+		t.Fatalf("New/NewWithOptions must not register clients in the idempotence map: len %d -> %d", before, after)
+	}
+}
+
 // 集成路径：验证导出的 Instrument 能给「裸」*rd.Client 补插桩 —— 即不经
 // New/NewWithOptions、需要 Eval/SetNX 等原语而直接构造的客户端(限流/锁/health)。
 // 同时验证幂等：连调两次 Instrument,一条 GET 只应产生一条样本（无 hook 层叠/重复计数）。

--- a/pkg/redis/instrument_test.go
+++ b/pkg/redis/instrument_test.go
@@ -122,3 +122,41 @@ func TestInstrumentClientReportsCommands(t *testing.T) {
 		t.Fatalf("expected a 'get' sample, got %+v", samples)
 	}
 }
+
+// 集成路径：验证导出的 Instrument 能给「裸」*rd.Client 补插桩 —— 即不经
+// New/NewWithOptions、需要 Eval/SetNX 等原语而直接构造的客户端(限流/锁/health)。
+// 需要真实 Redis。
+func TestInstrumentRawClientReportsCommands(t *testing.T) {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		t.Skip("REDIS_ADDR not set, skipping integration test")
+	}
+
+	var (
+		mu     sync.Mutex
+		sawGet bool
+	)
+	SetRedisObserver(func(cmd string, _ time.Duration, _ error) {
+		mu.Lock()
+		if cmd == "get" {
+			sawGet = true
+		}
+		mu.Unlock()
+	})
+	t.Cleanup(func() { SetRedisObserver(nil) })
+
+	// 裸客户端,不经 New/NewWithOptions,手动 Instrument。
+	client := rd.NewClient(&rd.Options{Addr: addr, Password: os.Getenv("REDIS_PASSWORD")})
+	defer func() { _ = client.Close() }()
+	Instrument(client)
+
+	if err := client.Get("test:instrument:raw:missing").Err(); err != nil && err != rd.Nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !sawGet {
+		t.Fatal("expected a 'get' sample from the manually-instrumented raw client")
+	}
+}

--- a/pkg/redis/instrument_test.go
+++ b/pkg/redis/instrument_test.go
@@ -77,8 +77,52 @@ func TestSetRedisObserverRoundTrip(t *testing.T) {
 	}
 }
 
-// 集成路径：需要真实 Redis。验证 WrapProcess 把命令名/未命中正确灌给 observer。
-func TestInstrumentClientReportsCommands(t *testing.T) {
+// 这些集成测试共享进程级 observer 单例,勿加 t.Parallel()。
+
+// Instrument(nil) 必须是安全 no-op,不得 panic。
+func TestInstrumentNilIsNoop(t *testing.T) {
+	Instrument(nil)
+}
+
+// 幂等性（非集成,CI 可跑）：对同一 client 连调两次 Instrument,一条命令只应产生一条
+// 样本。命令打向无人监听的地址会立即失败,但 WrapProcess 仍按「包了几层」触发对应次数
+// 的上报 —— 借此在没有真实 Redis 的情况下探测 hook 是否层叠。
+func TestInstrumentIdempotent(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		getCount int
+	)
+	SetRedisObserver(func(cmd string, _ time.Duration, _ error) {
+		mu.Lock()
+		if cmd == "get" {
+			getCount++
+		}
+		mu.Unlock()
+	})
+	t.Cleanup(func() { SetRedisObserver(nil) })
+
+	c := rd.NewClient(&rd.Options{Addr: "127.0.0.1:1", MaxRetries: 0, DialTimeout: 200 * time.Millisecond})
+	defer func() { _ = c.Close() }()
+	t.Cleanup(func() {
+		instrumentedMu.Lock()
+		delete(instrumented, c)
+		instrumentedMu.Unlock()
+	})
+
+	Instrument(c)
+	Instrument(c) // 幂等：第二次应为 no-op,不再叠一层 hook
+
+	_ = c.Get("k").Err() // 连接失败会返回 error,但 hook 仍会触发上报
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCount != 1 {
+		t.Fatalf("Instrument should be idempotent: want 1 'get' sample, got %d (hook stacked?)", getCount)
+	}
+}
+
+// 集成路径：需要真实 Redis。验证经 New（→Instrument）的 client 把命令名/未命中正确灌给 observer。
+func TestNewClientInstrumentedReportsCommands(t *testing.T) {
 	addr := os.Getenv("REDIS_ADDR")
 	if addr == "" {
 		t.Skip("REDIS_ADDR not set, skipping integration test")
@@ -125,6 +169,7 @@ func TestInstrumentClientReportsCommands(t *testing.T) {
 
 // 集成路径：验证导出的 Instrument 能给「裸」*rd.Client 补插桩 —— 即不经
 // New/NewWithOptions、需要 Eval/SetNX 等原语而直接构造的客户端(限流/锁/health)。
+// 同时验证幂等：连调两次 Instrument,一条 GET 只应产生一条样本（无 hook 层叠/重复计数）。
 // 需要真实 Redis。
 func TestInstrumentRawClientReportsCommands(t *testing.T) {
 	addr := os.Getenv("REDIS_ADDR")
@@ -133,21 +178,27 @@ func TestInstrumentRawClientReportsCommands(t *testing.T) {
 	}
 
 	var (
-		mu     sync.Mutex
-		sawGet bool
+		mu       sync.Mutex
+		getCount int
 	)
 	SetRedisObserver(func(cmd string, _ time.Duration, _ error) {
 		mu.Lock()
 		if cmd == "get" {
-			sawGet = true
+			getCount++
 		}
 		mu.Unlock()
 	})
 	t.Cleanup(func() { SetRedisObserver(nil) })
 
-	// 裸客户端,不经 New/NewWithOptions,手动 Instrument。
+	// 裸客户端,不经 New/NewWithOptions,手动 Instrument 两次（幂等：第二次应为 no-op）。
 	client := rd.NewClient(&rd.Options{Addr: addr, Password: os.Getenv("REDIS_PASSWORD")})
 	defer func() { _ = client.Close() }()
+	t.Cleanup(func() { // 别让测试用 client 滞留在全局幂等表里
+		instrumentedMu.Lock()
+		delete(instrumented, client)
+		instrumentedMu.Unlock()
+	})
+	Instrument(client)
 	Instrument(client)
 
 	if err := client.Get("test:instrument:raw:missing").Err(); err != nil && err != rd.Nil {
@@ -156,7 +207,7 @@ func TestInstrumentRawClientReportsCommands(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if !sawGet {
-		t.Fatal("expected a 'get' sample from the manually-instrumented raw client")
+	if getCount != 1 {
+		t.Fatalf("expected exactly 1 'get' sample (idempotent instrument), got %d", getCount)
 	}
 }

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -27,7 +27,7 @@ func New(addr string, password string) *Conn {
 		MaxRetries: 3, // 失败重试次数
 		Password:   password,
 	})
-	Instrument(c.client)
+	wrapClient(c.client)
 	return c
 }
 
@@ -46,7 +46,7 @@ func NewWithOptions(opts *rd.Options) *Conn {
 		local.MaxRetries = 3
 	}
 	client := rd.NewClient(&local)
-	Instrument(client)
+	wrapClient(client)
 	return &Conn{client: client}
 }
 

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -27,7 +27,7 @@ func New(addr string, password string) *Conn {
 		MaxRetries: 3, // 失败重试次数
 		Password:   password,
 	})
-	instrumentClient(c.client)
+	Instrument(c.client)
 	return c
 }
 
@@ -46,7 +46,7 @@ func NewWithOptions(opts *rd.Options) *Conn {
 		local.MaxRetries = 3
 	}
 	client := rd.NewClient(&local)
-	instrumentClient(client)
+	Instrument(client)
 	return &Conn{client: client}
 }
 


### PR DESCRIPTION
## What

Export the former unexported `instrumentClient` as **`redis.Instrument(*rd.Client)`** so a consumer can opt a **raw** go-redis client into the same per-command latency hook that `New`/`NewWithOptions` already install.

## Why

`#97` instrumented clients built via `pkg/redis` (`New`/`NewWithOptions`), which covers the shared cache (`ctx.GetRedisConn()`) — the data-plane bulk. But octo-server constructs **~15 raw `rd.NewClient(...)` instances** directly (rate-limit token bucket, OIDC state/bind/logout/locks, bot registry, user/group/space auth, health) because they need `Eval`/`Script`/`SetNX` primitives the `Conn` wrapper doesn't expose. Those bypass instrumentation entirely, so `dependency="redis"` is blind to the control plane — a real alerting hazard flagged across the #474 review (yujiawei / OctoBoooot / Octo-Q). This is the primary follow-up in #96.

With `Instrument` exported, the consumer can do:

```go
rlRedis := rd.NewClient(octoredis.MustBuildOptions(...))
redis.Instrument(rlRedis) // now its commands feed dependency="redis"
```

## Changes

- `pkg/redis/instrument.go` — rename unexported `instrumentClient` → exported `Instrument`; godoc documents the raw-client use case and warns the hook **stacks** on repeated calls (call once per client; don't re-instrument a `Conn`-built client).
- `pkg/redis/redis.go` — `New`/`NewWithOptions` now call `Instrument`.
- tests — add `TestInstrumentRawClientReportsCommands` (REDIS_ADDR-gated) driving a bare `rd.NewClient` + `Instrument` to confirm the exported path reports commands.

Purely additive: no signature changes to existing API; `New`/`NewWithOptions` behavior unchanged.

## Validation

`go build ./pkg/redis/...`, `go vet`, `go test ./pkg/redis` green; `golangci-lint` clean on the changed files. No lingering `instrumentClient` references.

Refs #96 — addresses the primary raw-client coverage follow-up; the remaining #96 items (blocking-command timing, doc nits, NewSqlite) stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHTDHbMPAVkNvYdQkh2ts3)_