### PR TITLE
feat(wkhttp): allow X-Scan-Poll-Secret in CORS preflight

### DIFF
--- a/pkg/wkhttp/cors_test.go
+++ b/pkg/wkhttp/cors_test.go
@@ -50,3 +50,48 @@ func TestCORSMiddlewareOptionsShortCircuits(t *testing.T) {
 		t.Errorf("OPTIONS status = %d, want 204", w.Code)
 	}
 }
+
+// TestCORSMiddlewareAdvertisesScanPollSecret 验证扫码登录的轮询凭据头出现在
+// Access-Control-Allow-Headers。
+//
+// 这个断言看着琐碎，但它挡的是一个静默失效：自定义请求头会让请求变成非简单请求，
+// 跨源浏览器先发 OPTIONS 预检；头不在清单里，预检就拒掉**真正的请求**，服务端连
+// handler 都进不去。表现是「跨源部署扫码登录完全不可用」，而同源部署一切正常 ——
+// 本地和 CI 都测不出来。
+func TestCORSMiddlewareAdvertisesScanPollSecret(t *testing.T) {
+	wk := New()
+	wk.Use(CORSMiddleware())
+	wk.GET("/", noopHandler)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	wk.ServeHTTP(w, req)
+
+	allow := w.Header().Get("Access-Control-Allow-Headers")
+	if !strings.Contains(allow, "X-Scan-Poll-Secret") {
+		t.Errorf("AllowHeaders missing %q: %s", "X-Scan-Poll-Secret", allow)
+	}
+}
+
+// TestCORSMiddlewarePreflightAllowsScanPollSecret 走真实的预检形状：带
+// Access-Control-Request-Headers 的 OPTIONS，断言 204 且该头被 advertise。
+func TestCORSMiddlewarePreflightAllowsScanPollSecret(t *testing.T) {
+	wk := New()
+	wk.Use(CORSMiddleware())
+	wk.GET("/v1/user/loginstatus", noopHandler)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/v1/user/loginstatus", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Access-Control-Request-Headers", "X-Scan-Poll-Secret")
+	wk.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want 204", w.Code)
+	}
+	allow := w.Header().Get("Access-Control-Allow-Headers")
+	if !strings.Contains(allow, "X-Scan-Poll-Secret") {
+		t.Fatalf("preflight would reject the real request; AllowHeaders = %s", allow)
+	}
+}

--- a/pkg/wkhttp/http.go
+++ b/pkg/wkhttp/http.go
@@ -421,15 +421,24 @@ func (r *RouterGroup) PUT(relativePath string, handlers ...HandlerFunc) {
 //   - X-Octo-Lang: 客户端显式覆盖语言（优先级高于 Accept-Language）
 //   - Accept-Language: 标准协商语言头
 //
+// 以及扫码登录的轮询凭据头：
+//   - X-Scan-Poll-Secret: GET /v1/user/loginstatus 的轮询密钥。只有持有它的调用方才能
+//     从二维码状态里读到 auth_code —— 走请求头而非 query 是为了让明文不进 access log。
+//
 // ExposeHeaders 是新增字段（历史 CORSMiddleware 完全没有这一行）：
 //   - Content-Language: 实际返回的响应语言，浏览器可读
 //   - Vary: 让代理 / 浏览器按语言变体缓存
+//
+// 注意这份 AllowHeaders 清单是**写死**的，且 OPTIONS 分支设置完就立刻
+// AbortWithStatus(204)、response header 当场 flush —— 下游仓库无论把自己的中间件挂在
+// 本中间件之前还是之后都改不动它。所以任何新的自定义请求头都必须在这里登记，否则跨源
+// 浏览器的预检直接拒掉整个请求（不是降级，是真正的请求根本发不出去）。
 func CORSMiddleware() HandlerFunc {
 
 	return func(c *Context) {
 		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, token, accept, origin, Cache-Control, X-Requested-With, appid, noncestr, sign, timestamp, X-Octo-Error-Envelope, X-Octo-Lang, Accept-Language")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, token, accept, origin, Cache-Control, X-Requested-With, appid, noncestr, sign, timestamp, X-Octo-Error-Envelope, X-Octo-Lang, Accept-Language, X-Scan-Poll-Secret")
 		c.Writer.Header().Set("Access-Control-Expose-Headers", "Content-Language, Vary")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT,DELETE,PATCH")
 


### PR DESCRIPTION
## Summary

Adds `X-Scan-Poll-Secret` to `CORSMiddleware`'s hardcoded
`Access-Control-Allow-Headers` list.

octo-server's scan-login fix (Mininglamp-OSS/octo-server#715) gates the credential fields
of `GET /v1/user/loginstatus` behind a poll secret, carried in an `X-Scan-Poll-Secret`
request header rather than a query parameter so the plaintext stays out of nginx/CDN access
logs, APM spans and browser history.

A custom request header makes that poll a **non-simple request**, so a cross-origin browser
preflights it. `AllowHeaders` here is a hardcoded string, and the `OPTIONS` branch calls
`AbortWithStatus(204)` immediately after setting it — response headers are flushed at that
point, so a downstream repo **cannot** extend the list from its own middleware, whether it
mounts before or after this one. Without the header registered here, the preflight rejects
the real request outright: cross-origin scan-login breaks entirely rather than degrading.

The failure mode is worth naming because it is invisible in normal development:
same-origin deployments (octo-web serves `/api/v1/` as a relative path) are completely
unaffected, so this does not reproduce locally or in CI. It only bites the Tauri/Electron
desktop build, which connects to an absolute API origin.

Caught in review on octo-server#715 by @yujiawei.

## Changes

- `pkg/wkhttp/http.go` — append `X-Scan-Poll-Secret` to `Access-Control-Allow-Headers`;
  extend the doc comment to record *why* every new custom header has to be registered in
  this one place (hardcoded list + early abort ⇒ not extensible downstream).
- `pkg/wkhttp/cors_test.go` — two tests:
  - `TestCORSMiddlewareAdvertisesScanPollSecret` — the header is advertised
  - `TestCORSMiddlewarePreflightAllowsScanPollSecret` — drives the real preflight shape
    (`OPTIONS` + `Origin` + `Access-Control-Request-Method` + `Access-Control-Request-Headers`)
    and asserts 204 plus the advertisement

## Testing

```
go build ./...
go test ./pkg/wkhttp/ -count=1        # ok
go test ./pkg/wkhttp/ -run TestCORSMiddleware -v   # 4/4 pass
```

Pure additive change to a response header value; no behaviour change for any existing
header or route.

## Downstream

octo-server#715 currently reads the secret from the header **with a `poll_secret` query
fallback**, precisely because this PR had not landed. Once this merges and octo-server bumps
its `octo-lib` pseudo-version, that query fallback and its octo-web counterpart should be
deleted — both are marked with a `SUNSET` comment naming this exact condition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXex3UKTdUPzsV9m1QEpJp)_