### PR TITLE
fix(wkhttp): export proxy-aware client IP

### DIFF
--- a/pkg/util/ip.go
+++ b/pkg/util/ip.go
@@ -27,6 +27,8 @@ func GetExternalIP() (string, error) {
 
 // GetClientPublicIP 尽最大努力实现获取客户端公网 IP 的算法。
 // 解析 X-Real-IP 和 X-Forwarded-For 以便于反向代理（nginx 或 haproxy）可以正常工作。
+// 本函数保留展示和地理位置场景的兼容语义；安全敏感的限流或审计归因应使用
+// pkg/wkhttp.ClientIP，并满足其受信代理契约。
 func GetClientPublicIP(r *http.Request) string {
 	var ip string
 	for _, ip = range strings.Split(r.Header.Get("X-Forwarded-For"), ",") {

--- a/pkg/wkhttp/ratelimit.go
+++ b/pkg/wkhttp/ratelimit.go
@@ -184,16 +184,15 @@ func setRateLimitHeaders(h http.Header, scope string, burst, remaining int, allo
 	}
 }
 
-// getClientIP 从请求头按优先级取客户端 IP。
-// 生产架构为腾讯云 CLB 直连 Pod（pass-to-target），单层代理，XFF 只含客户端真实 IP。
-// 若未来新增 CDN 或多层反代，需重新评估 rightmost XFF 的取值是否正确。
+// ClientIP 从请求头按优先级取客户端 IP。
+// 生产架构为腾讯云 CLB 直连 Pod（pass-to-target）的单层代理：CLB 必须覆盖或剥离
+// 客户端传入的 X-Real-Ip，并把实际来源追加为 XFF 最右项。若未来新增 CDN 或多层
+// 反代，需重新评估 rightmost XFF 的取值是否正确。
 //
 // ⚠️ 信任假设（部署方必须保证）：本函数直接信任 X-Real-Ip / X-Forwarded-For。
-// 仅当上游存在受信反代（CLB / Nginx / Envoy 等）会**剥离客户端伪造的同名头**
-// 并写入真实客户端 IP 时，per-IP 限流才有效。若服务对外暴露时绕过反代直连，
-// 客户端可任意伪造这两个头绕过限流——部署方需在反代/网络策略层面阻断。
-// 复用本中间件的新服务务必校验该前提。
-func getClientIP(r *http.Request) string {
+// 仅当受信反代遵守上述 header 契约，且服务无法绕过反代直连时，per-IP 限流和
+// 审计归因才有效。复用本函数的新服务务必校验该前提。
+func ClientIP(r *http.Request) string {
 	if ip := strings.TrimSpace(r.Header.Get("X-Real-Ip")); ip != "" {
 		return ip
 	}
@@ -248,7 +247,7 @@ func (l *WKHttp) RateLimitMiddleware(ctx context.Context, client *rd.Client, rps
 		}
 
 		// fail-closed: 拿不到 IP 时走全局桶，不放行
-		ip := getClientIP(c.Request)
+		ip := ClientIP(c.Request)
 		if ip == "" {
 			unknownIPWarnOnce.Do(func() {
 				log.Warn("rate limit: client IP unavailable, falling back to shared bucket; check reverse proxy / XFF configuration")
@@ -293,7 +292,7 @@ func (l *WKHttp) StrictIPRateLimitMiddleware(ctx context.Context, client *rd.Cli
 	var unknownIPWarnOnce sync.Once
 
 	return func(c *Context) {
-		ip := getClientIP(c.Request)
+		ip := ClientIP(c.Request)
 		if ip == "" {
 			unknownIPWarnOnce.Do(func() {
 				log.Warn("strict rate limit: client IP unavailable, falling back to shared bucket; check reverse proxy / XFF configuration")

--- a/pkg/wkhttp/ratelimit.go
+++ b/pkg/wkhttp/ratelimit.go
@@ -204,9 +204,11 @@ func setRateLimitHeaders(h http.Header, scope string, burst, remaining int, allo
 func ClientIP(r *http.Request) string {
 	if values := r.Header.Values("X-Forwarded-For"); len(values) > 0 {
 		parts := strings.Split(values[len(values)-1], ",")
-		if candidate := strings.TrimSpace(parts[len(parts)-1]); candidate != "" {
-			return canonicalClientIP(candidate)
+		candidate := strings.TrimSpace(parts[len(parts)-1])
+		if candidate == "" {
+			return ""
 		}
+		return canonicalClientIP(candidate)
 	}
 
 	if values := r.Header.Values("X-Real-Ip"); len(values) > 0 {

--- a/pkg/wkhttp/ratelimit.go
+++ b/pkg/wkhttp/ratelimit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -184,28 +185,51 @@ func setRateLimitHeaders(h http.Header, scope string, burst, remaining int, allo
 	}
 }
 
-// ClientIP 从请求头按优先级取客户端 IP。
-// 生产架构为腾讯云 CLB 直连 Pod（pass-to-target）的单层代理：CLB 必须覆盖或剥离
-// 客户端传入的 X-Real-Ip，并把实际来源追加为 XFF 最右项。若未来新增 CDN 或多层
-// 反代，需重新评估 rightmost XFF 的取值是否正确。
+// ClientIP returns a canonical client IP selected for security-sensitive rate
+// limiting and audit attribution behind one trusted reverse proxy.
+//
+// X-Forwarded-For is authoritative when present: the proxy must append the
+// actual source as the rightmost entry, either to the comma-separated final
+// field line or as a new final field line. X-Real-Ip is only a fallback and
+// duplicate X-Real-Ip fields fail closed. Invalid candidates return an empty
+// string so callers can use their shared unknown-IP bucket.
+//
+// 生产架构为腾讯云 CLB 直连 Pod（pass-to-target）的单层代理。若未来新增 CDN 或
+// 多层反代，需重新评估 rightmost XFF 的取值是否正确。
 //
 // ⚠️ 信任假设（部署方必须保证）：本函数直接信任 X-Real-Ip / X-Forwarded-For。
-// 仅当受信反代遵守上述 header 契约，且服务无法绕过反代直连时，per-IP 限流和
-// 审计归因才有效。复用本函数的新服务务必校验该前提。
+// 仅当受信反代遵守上述 header 契约，且服务无法绕过反代直连时，per-IP 限流和审计
+// 归因才有效。否则客户端可伪造这两个头绕过限流并污染审计，部署方必须在反代和网络
+// 策略层阻断直连。该语义也不同于 gin.Context.ClientIP；安全路径应显式调用本函数。
 func ClientIP(r *http.Request) string {
-	if ip := strings.TrimSpace(r.Header.Get("X-Real-Ip")); ip != "" {
-		return ip
-	}
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		parts := strings.Split(xff, ",")
-		if ip := strings.TrimSpace(parts[len(parts)-1]); ip != "" {
-			return ip
+	if values := r.Header.Values("X-Forwarded-For"); len(values) > 0 {
+		parts := strings.Split(values[len(values)-1], ",")
+		if candidate := strings.TrimSpace(parts[len(parts)-1]); candidate != "" {
+			return canonicalClientIP(candidate)
 		}
 	}
+
+	if values := r.Header.Values("X-Real-Ip"); len(values) > 0 {
+		if len(values) != 1 {
+			return ""
+		}
+		if candidate := strings.TrimSpace(values[0]); candidate != "" {
+			return canonicalClientIP(candidate)
+		}
+	}
+
 	if ip, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr)); err == nil {
-		return ip
+		return canonicalClientIP(ip)
 	}
 	return ""
+}
+
+func canonicalClientIP(value string) string {
+	addr, err := netip.ParseAddr(strings.TrimSpace(value))
+	if err != nil || addr.Zone() != "" {
+		return ""
+	}
+	return addr.Unmap().String()
 }
 
 // rateLimitErrorSpec 构造限流错误描述。所有三个限流中间件共用。

--- a/pkg/wkhttp/ratelimit.go
+++ b/pkg/wkhttp/ratelimit.go
@@ -203,8 +203,11 @@ func setRateLimitHeaders(h http.Header, scope string, burst, remaining int, allo
 // 策略层阻断直连。该语义也不同于 gin.Context.ClientIP；安全路径应显式调用本函数。
 func ClientIP(r *http.Request) string {
 	if values := r.Header.Values("X-Forwarded-For"); len(values) > 0 {
-		parts := strings.Split(values[len(values)-1], ",")
-		candidate := strings.TrimSpace(parts[len(parts)-1])
+		last := values[len(values)-1]
+		if i := strings.LastIndexByte(last, ','); i >= 0 {
+			last = last[i+1:]
+		}
+		candidate := strings.TrimSpace(last)
 		if candidate == "" {
 			return ""
 		}

--- a/pkg/wkhttp/ratelimit_test.go
+++ b/pkg/wkhttp/ratelimit_test.go
@@ -43,23 +43,99 @@ func cleanRateLimitKeys(t *testing.T, c *rd.Client) {
 func TestClientIP(t *testing.T) {
 	tests := []struct {
 		name       string
-		realIP     string
-		forwarded  string
+		headers    http.Header
 		remoteAddr string
 		want       string
 	}{
 		{
-			name:       "x-real-ip has priority",
-			realIP:     " 192.0.2.10 ",
-			forwarded:  "203.0.113.10, 198.51.100.24",
+			name: "rightmost xff has priority over x-real-ip",
+			headers: http.Header{
+				"X-Forwarded-For": {"203.0.113.10, 198.51.100.24"},
+				"X-Real-Ip":       {"192.0.2.10"},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "198.51.100.24",
+		},
+		{
+			name: "trusted proxy comma-appends actual ip to xff",
+			headers: http.Header{
+				"X-Forwarded-For": {"203.0.113.10,  198.51.100.24 "},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "198.51.100.24",
+		},
+		{
+			name: "trusted proxy appends a second xff field line",
+			headers: http.Header{
+				"X-Forwarded-For": {"203.0.113.10", "198.51.100.24"},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "198.51.100.24",
+		},
+		{
+			name: "duplicate x-real-ip without xff fails closed",
+			headers: http.Header{
+				"X-Real-Ip": {"203.0.113.10", "198.51.100.24"},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "",
+		},
+		{
+			name: "whitespace x-real-ip falls back to remote address",
+			headers: http.Header{
+				"X-Real-Ip": {"  "},
+			},
+			remoteAddr: "198.51.100.24:8080",
+			want:       "198.51.100.24",
+		},
+		{
+			name: "invalid xff fails closed instead of trusting x-real-ip",
+			headers: http.Header{
+				"X-Forwarded-For": {"203.0.113.10, not-an-ip"},
+				"X-Real-Ip":       {"192.0.2.10"},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "",
+		},
+		{
+			name: "sentinel collision input fails closed",
+			headers: http.Header{
+				"X-Real-Ip": {unknownIPKey},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "",
+		},
+		{
+			name: "oversized header input fails closed",
+			headers: http.Header{
+				"X-Real-Ip": {strings.Repeat("a", 4096)},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "",
+		},
+		{
+			name: "ipv6 xff is canonicalized",
+			headers: http.Header{
+				"X-Forwarded-For": {"2001:0DB8:0000:0000:0000:0000:0000:0001"},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "2001:db8::1",
+		},
+		{
+			name: "ipv4-mapped ipv6 is unmapped",
+			headers: http.Header{
+				"X-Forwarded-For": {"::ffff:192.0.2.10"},
+			},
 			remoteAddr: "10.0.0.5:443",
 			want:       "192.0.2.10",
 		},
 		{
-			name:       "trusted proxy appends actual ip to xff",
-			forwarded:  "203.0.113.10,  198.51.100.24 ",
+			name: "ipv6 zone identifier fails closed",
+			headers: http.Header{
+				"X-Forwarded-For": {"fe80::1%eth0"},
+			},
 			remoteAddr: "10.0.0.5:443",
-			want:       "198.51.100.24",
+			want:       "",
 		},
 		{
 			name:       "ipv4 remote address fallback",
@@ -68,7 +144,7 @@ func TestClientIP(t *testing.T) {
 		},
 		{
 			name:       "empty rightmost xff falls back to remote address",
-			forwarded:  "203.0.113.10,  ",
+			headers:    http.Header{"X-Forwarded-For": {"203.0.113.10,  "}},
 			remoteAddr: "198.51.100.24:8080",
 			want:       "198.51.100.24",
 		},
@@ -78,8 +154,13 @@ func TestClientIP(t *testing.T) {
 			want:       "2001:db8::24",
 		},
 		{
-			name:       "unusable remote address",
+			name:       "unusable remote address without port",
 			remoteAddr: "not-an-address",
+			want:       "",
+		},
+		{
+			name:       "non-ip remote host fails closed",
+			remoteAddr: "not-an-ip:443",
 			want:       "",
 		},
 	}
@@ -88,11 +169,10 @@ func TestClientIP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.RemoteAddr = tt.remoteAddr
-			if tt.realIP != "" {
-				req.Header.Set("X-Real-Ip", tt.realIP)
-			}
-			if tt.forwarded != "" {
-				req.Header.Set("X-Forwarded-For", tt.forwarded)
+			for name, values := range tt.headers {
+				for _, value := range values {
+					req.Header.Add(name, value)
+				}
 			}
 
 			if got := ClientIP(req); got != tt.want {

--- a/pkg/wkhttp/ratelimit_test.go
+++ b/pkg/wkhttp/ratelimit_test.go
@@ -143,10 +143,10 @@ func TestClientIP(t *testing.T) {
 			want:       "198.51.100.24",
 		},
 		{
-			name:       "empty rightmost xff falls back to remote address",
+			name:       "empty rightmost xff fails closed",
 			headers:    http.Header{"X-Forwarded-For": {"203.0.113.10,  "}},
 			remoteAddr: "198.51.100.24:8080",
-			want:       "198.51.100.24",
+			want:       "",
 		},
 		{
 			name:       "ipv6 remote address fallback",

--- a/pkg/wkhttp/ratelimit_test.go
+++ b/pkg/wkhttp/ratelimit_test.go
@@ -73,6 +73,14 @@ func TestClientIP(t *testing.T) {
 			want:       "198.51.100.24",
 		},
 		{
+			name: "oversized xff prefix keeps trusted rightmost ip",
+			headers: http.Header{
+				"X-Forwarded-For": {strings.Repeat(",", 64<<10) + "198.51.100.24"},
+			},
+			remoteAddr: "10.0.0.5:443",
+			want:       "198.51.100.24",
+		},
+		{
 			name: "duplicate x-real-ip without xff fails closed",
 			headers: http.Header{
 				"X-Real-Ip": {"203.0.113.10", "198.51.100.24"},
@@ -179,6 +187,25 @@ func TestClientIP(t *testing.T) {
 				t.Fatalf("ClientIP() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClientIPOversizedXFFAllocationsBounded(t *testing.T) {
+	const want = "198.51.100.24"
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", strings.Repeat(",", 64<<10)+want)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if got := ClientIP(req); got != want {
+				b.Fatalf("ClientIP() = %q, want %q", got, want)
+			}
+		}
+	})
+
+	const maxBytesPerOp = 128 << 10
+	if got := result.AllocedBytesPerOp(); got > maxBytesPerOp {
+		t.Fatalf("ClientIP() allocated %d bytes/op for oversized XFF, want <= %d", got, maxBytesPerOp)
 	}
 }
 

--- a/pkg/wkhttp/ratelimit_test.go
+++ b/pkg/wkhttp/ratelimit_test.go
@@ -40,6 +40,68 @@ func cleanRateLimitKeys(t *testing.T, c *rd.Client) {
 	}
 }
 
+func TestClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		realIP     string
+		forwarded  string
+		remoteAddr string
+		want       string
+	}{
+		{
+			name:       "x-real-ip has priority",
+			realIP:     " 192.0.2.10 ",
+			forwarded:  "203.0.113.10, 198.51.100.24",
+			remoteAddr: "10.0.0.5:443",
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "trusted proxy appends actual ip to xff",
+			forwarded:  "203.0.113.10,  198.51.100.24 ",
+			remoteAddr: "10.0.0.5:443",
+			want:       "198.51.100.24",
+		},
+		{
+			name:       "ipv4 remote address fallback",
+			remoteAddr: "198.51.100.24:8080",
+			want:       "198.51.100.24",
+		},
+		{
+			name:       "empty rightmost xff falls back to remote address",
+			forwarded:  "203.0.113.10,  ",
+			remoteAddr: "198.51.100.24:8080",
+			want:       "198.51.100.24",
+		},
+		{
+			name:       "ipv6 remote address fallback",
+			remoteAddr: "[2001:db8::24]:8080",
+			want:       "2001:db8::24",
+		},
+		{
+			name:       "unusable remote address",
+			remoteAddr: "not-an-address",
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.realIP != "" {
+				req.Header.Set("X-Real-Ip", tt.realIP)
+			}
+			if tt.forwarded != "" {
+				req.Header.Set("X-Forwarded-For", tt.forwarded)
+			}
+
+			if got := ClientIP(req); got != tt.want {
+				t.Fatalf("ClientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestNewKeyedLimiterRejectsInvalidConfig 验证启动期校验：rps<=0 或 burst<=0
 // 触发 panic（loud-fast），防止配置错误悄悄变成 100% 429（Lua fail-closed 早返回）。
 func TestNewKeyedLimiterRejectsInvalidConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Export and harden the proxy-aware client IP selector used by wkhttp rate limiting so downstream security-sensitive audit paths can use the same validated source of truth.

For the documented single trusted-proxy topology, the final `X-Forwarded-For` entry is authoritative. `X-Real-Ip` is a fallback only, duplicate `X-Real-Ip` fields fail closed, and all selected values are validated and canonicalized before becoming rate-limit or audit keys.

## Related Issue

No public issue. This is the upstream dependency for the octo-server login-audit IP spoofing hardening.

## Changes

- Export `wkhttp.ClientIP` and reuse it from global and strict IP rate-limit middleware.
- Read repeated XFF field lines correctly and select the final proxy-appended entry.
- Validate candidates with `net/netip`, canonicalize IPv6, unmap IPv4-in-IPv6, and reject invalid or zoned values.
- Treat XFF as authoritative over `X-Real-Ip`; reject ambiguous duplicate `X-Real-Ip` fields.
- Document the trusted-proxy/direct-connect contract, the difference from Gin `Context.ClientIP`, and the non-security role of `util.GetClientPublicIP`.
- Add table-driven coverage for spoofed/repeated headers, invalid and oversized input, sentinel collision, IPv4/IPv6 canonicalization, and `RemoteAddr` fallback.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands run:

```text
go test ./pkg/wkhttp/... -count=1
go test -race ./pkg/wkhttp -run ^TestClientIP$ -count=1
go test ./... -count=1
go vet ./...
golangci-lint run ./...
```

`ClientIP` and its canonicalization helper both have 100% statement coverage in the focused test.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
